### PR TITLE
added properties.ini file required by PA

### DIFF
--- a/RHEL6_7/properties.ini
+++ b/RHEL6_7/properties.ini
@@ -1,0 +1,3 @@
+[preupgrade-assistant-modules]
+src_major_version=6
+dst_major_version=7


### PR DESCRIPTION
The file will be required by next version of Preupgrade Assistant so it will not be dependent on the name of the directory as it was previously.