### PR TITLE
Remove dependency on redhat-upgrade-tool (Resolves: #8)

### DIFF
--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -17,9 +17,6 @@ BuildRoot:      %{_tmppath}/%{pkg_name}-%{version}-%{release}-root-%(%{__id_u} -
 Requires:       preupgrade-assistant >= 2.4.4
 BuildRequires:  preupgrade-assistant-tools >= 2.4.4
 
-#pkgdowngrades module is crucial and requires redhat-upgrade-tool
-Requires:       redhat-upgrade-tool >= 0.7.49
-
 # static data are required by our modules & old contents
 # are obsoleted by this package
 Obsoletes:      preupgrade-assistant-contents < 0.6.41-6


### PR DESCRIPTION
The dependency on redhat-upgrade-tool (r-u-t) is pointless because
scan of system is independent on the tool. r-u-t is needed only for
the in-place upgrade process itself.