### PR TITLE
use current API for modules from PA v2.4.5

### DIFF
--- a/RHEL6_7/databases/mysql/configuration_changes/check
+++ b/RHEL6_7/databases/mysql/configuration_changes/check
@@ -5,8 +5,8 @@
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 source ../mysql-common.sh
 
@@ -172,7 +172,7 @@ provide the same functionality as you have now:" >> "$SOLUTION_FILE"
     else
       cat "$OPTION_FIXED_FILE" | sort | uniq >> "$SOLUTION_FILE"
     fi
-    result=$RESULT_FAILED
+    result=$RESULT_FAIL
 fi
 
 if [ ! -f "$OPTION_NOT_OK_FILE" ]; then
@@ -183,10 +183,10 @@ else
 Some options were not commented out in the files listed below and therefore MariaDB 5.5 might fail unexpectedly.
 The listed options should be replaced or commented out manually:" >> "$SOLUTION_FILE"
     cat "$OPTION_NOT_OK_FILE" | sort | uniq >> "$SOLUTION_FILE"
-    result=$RESULT_FAILED
+    result=$RESULT_FAIL
 fi
 
-[ "$result" == "$RESULT_FAILED" ] && echo "
+[ "$result" == "$RESULT_FAIL" ] && echo "
 The files mentioned above are backups of your original configuration files.
 After the upgrade you must manually replace the contents of the default
 MariaDB 5.5 configuration (as is appropriate to your environment) with the

--- a/RHEL6_7/databases/mysql/data_migration/check
+++ b/RHEL6_7/databases/mysql/data_migration/check
@@ -7,8 +7,8 @@ check_rpm_to "bash" ""
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 source ../mysql-common.sh
 export datadir

--- a/RHEL6_7/databases/mysql/general_changes/check
+++ b/RHEL6_7/databases/mysql/general_changes/check
@@ -6,8 +6,8 @@ check_rpm_to "bash" ""
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 PLUGINDIR="/usr/lib64/mysql/plugin"
 

--- a/RHEL6_7/networking/dovecot/check
+++ b/RHEL6_7/networking/dovecot/check
@@ -4,8 +4,8 @@
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 # Copy your config file from RHEL6 (in case of scenario RHEL6_7)
 # to Temporary Directory
@@ -55,7 +55,7 @@ then
 else
   log_error "Cannot use doveconf to parse the configuration files."
   rm -f $TMPF1 $TMPF2
-  exit $RESULT_FAILED
+  exit $RESULT_FAIL
 fi
 
 log_info "The configuration files from $CONFIG_FILE will be fixed by the postupgrade script."

--- a/RHEL6_7/networking/iptables/check
+++ b/RHEL6_7/networking/iptables/check
@@ -4,7 +4,7 @@ check_applies_to "iptables"
 
 #END GENERATED SECTION
 
-check_root
+
 
 custom_scf=false
 custom_iptables=false

--- a/RHEL6_7/networking/postfix/check
+++ b/RHEL6_7/networking/postfix/check
@@ -17,8 +17,8 @@ CONFIG_FILE="/etc/postfix/main.cf"
 [ -f "$CONFIG_FILE" ] ||
   exit_not_applicable
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 
 mkdir -p $VALUE_TMP_PREUPGRADE/cleanconf/$(dirname $CONFIG_FILE)

--- a/RHEL6_7/networking/sendmail/check
+++ b/RHEL6_7/networking/sendmail/check
@@ -17,8 +17,8 @@ CONFIG_FILE="/etc/sysconfig/sendmail"
 [ -f "$CONFIG_FILE" ] ||
   exit_not_applicable
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 
 mkdir -p $VALUE_TMP_PREUPGRADE/cleanconf/$(dirname $CONFIG_FILE)

--- a/RHEL6_7/networking/squid/check
+++ b/RHEL6_7/networking/squid/check
@@ -11,8 +11,8 @@ if [ ! -f /etc/squid/squid.conf ] ; then
     exit $RESULT_NOT_APPLICABLE;
 fi
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 # Copy your config file from RHEL6 (in case of scenario RHEL6_7) 
 # to Temporary Directory

--- a/RHEL6_7/others/configchanges/check
+++ b/RHEL6_7/others/configchanges/check
@@ -3,7 +3,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 AUDIT_FLAG=0
 fix_audit65="fix_audit65.sh"
 

--- a/RHEL6_7/others/rsyslog/check
+++ b/RHEL6_7/others/rsyslog/check
@@ -3,7 +3,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 rm -f solution.txt
 touch solution.txt
 

--- a/RHEL6_7/packages/LoadBalanceSupport/check
+++ b/RHEL6_7/packages/LoadBalanceSupport/check
@@ -4,7 +4,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 
 if [ -z "$SOLUTION_FILE" ]; then
   cat /dev/null > ./solution.txt

--- a/RHEL6_7/packages/ReplacedPackages/check
+++ b/RHEL6_7/packages/ReplacedPackages/check
@@ -130,7 +130,7 @@ do
     }
     other_repositories="${other_repositories}$channel "
     msg_channel=" ($channel channel in Red Hat Enterprise Linux 7)"
-    statuscode=$RESULT_FAILED
+    statuscode=$RESULT_FAIL
     filename_suffix="-notbase"
   fi
 

--- a/RHEL6_7/selinux/CustomPolicy/check
+++ b/RHEL6_7/selinux/CustomPolicy/check
@@ -3,7 +3,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 fix_script="fix_SELinuxCustomPolicy.sh"
 
 rm -f solution.txt

--- a/RHEL6_7/selinux/RestoreConfig/check
+++ b/RHEL6_7/selinux/RestoreConfig/check
@@ -5,8 +5,8 @@ check_applies_to "policycoreutils-python"
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 SEMANAGE_EXPORT_FILE=semanage_export
 

--- a/RHEL6_7/services/cupsbrowsing/check
+++ b/RHEL6_7/services/cupsbrowsing/check
@@ -37,18 +37,18 @@ RESULT=$RESULT_FIXED
 
 if grep -qiw LDAP <(echo "$BROWSELOCALPROTOCOLS $BROWSEREMOTEPROTOCOLS"); then
     log_high_risk "LDAP browsing is no longer available in CUPS."
-    RESULT=$RESULT_FAILED
+    RESULT=$RESULT_FAIL
 fi
 
 if [ -n "$BROWSEPORT" ] && [ "$BROWSEPORT" -ne 631 ]; then
     log_high_risk "The CUPS BrowsePort directive cannot be migrated to cups-browsed."
-    RESULT=$RESULT_FAILED
+    RESULT=$RESULT_FAIL
 fi
 
 if [ -n "$BROWSESHORTNAMES" ]; then
     if ! grep -qiw "$BROWSESHORTNAMES" <(echo $TRUE); then
 	log_high_risk "The 'BrowseShortNames No' CUPS directive cannot be migrated to cups-browsed."
-	RESULT=$RESULT_FAILED
+	RESULT=$RESULT_FAIL
     fi
 fi
 
@@ -82,7 +82,7 @@ if [ "$SEND_BROWSE" != 0 ]; then
     # BrowseAddress is not understood by cups-browsed.
     if grep -i '^ *BrowseAddress ' "$CUPSD_CONF"; then
 	log_high_risk "CUPS Browsing is currently used to advertise queues. However, the BrowseAddress directive has been deprecated and cannot be migrated to the cups-browsed service."
-	RESULT=$RESULT_FAILED
+	RESULT=$RESULT_FAIL
     fi
 fi
 if [ "$RECV_BROWSE" != 0 ]; then
@@ -93,13 +93,13 @@ if [ "$RECV_BROWSE" != 0 ]; then
     # understood, so watch out for it.
     if grep -i '^ *BrowseAllow ' "$CUPSD_CONF" | grep -q '^[^#]*@'; then
 	log_high_risk "CUPS Browsing is currently used to discover CUPS queues. However, the BrowseAllow directive has been deprecated and cannot be migrated to the cups-browsed service."
-	RESULT=$RESULT_FAILED
+	RESULT=$RESULT_FAIL
     fi
 
     # BrowseDeny is not understood at all.
     if grep -qi '^ *BrowseDeny ' "$CUPSD_CONF"; then
 	log_high_risk "CUPS Browsing is currently used to discover CUPS queues. However, the BrowseDeny directive has been deprecated and cannot be migrated to the cups-browsed service."
-	RESULT=$RESULT_FAILED
+	RESULT=$RESULT_FAIL
     fi
 
     grep -i '^ *BrowseAllow ' "$CUPSD_CONF" | grep -v '^[^#]*@' \

--- a/RHEL6_7/services/httpd/check
+++ b/RHEL6_7/services/httpd/check
@@ -6,8 +6,8 @@ check_rpm_to "" ""
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 # Copy your config file from RHEL6 (in case of scenario RHEL6_7)
 # to Temporary Directory

--- a/RHEL6_7/services/ntp/configuration/check
+++ b/RHEL6_7/services/ntp/configuration/check
@@ -2,7 +2,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 
 # The RHEL6 ntp and ntpdate configuration can be used without changes on RHEL7.
 # Some configuration files are not copied to the cleanconf directory

--- a/RHEL6_7/services/openssh/sshd/check
+++ b/RHEL6_7/services/openssh/sshd/check
@@ -5,8 +5,8 @@ check_applies_to "openssh-server"
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 SSHD_CONFIG_FILE=/etc/ssh/sshd_config
 

--- a/RHEL6_7/services/openssh/sysconfig/check
+++ b/RHEL6_7/services/openssh/sysconfig/check
@@ -5,8 +5,8 @@ check_applies_to "openssh-server"
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 SYSCONFIG_FILE=/etc/sysconfig/sshd
 

--- a/RHEL6_7/services/sssd/check
+++ b/RHEL6_7/services/sssd/check
@@ -4,7 +4,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 check_applies_to "sssd"
 
 function solution() {

--- a/RHEL6_7/services/tomcat/check
+++ b/RHEL6_7/services/tomcat/check
@@ -146,9 +146,9 @@ def _set_exit_func(efunc):
     global _use_exit_func
     if efunc is exit_error:
         _use_exit_func = exit_error
-    elif efunc in [exit_fail, exit_failed] and _use_exit_func is not exit_error:
+    elif efunc is exit_fail and _use_exit_func is not exit_error:
         _use_exit_func = exit_fail
-    elif efunc is exit_fixed and _use_exit_func not in [exit_error, exit_fail, exit_failed]:
+    elif efunc is exit_fixed and _use_exit_func not in [exit_error, exit_fail]:
         _use_exit_func = exit_fixed
     elif efunc is exit_informational and _use_exit_func is exit_pass:
         _use_exit_func = exit_informational

--- a/RHEL6_7/storage/cryptsetup-luks/check
+++ b/RHEL6_7/storage/cryptsetup-luks/check
@@ -2,7 +2,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 
 CONFIG_FILE=/etc/crypttab
 
@@ -108,7 +108,7 @@ function check_crypttab()
 		if [ $? -ne 0 ]; then
 			log_error "Whirlpool hash spec detected in a LUKS device ($src) specified in crypttab"
 			log_high_risk "The in-place upgrade cannot proceed further. The system with such a LUKS device in crypttab risks being left unbootable after the upgrade."
-			wrap_exit $RESULT_FAILED
+			wrap_exit $RESULT_FAIL
 		fi
 	done < $VALUE_TMP_PREUPGRADE$CONFIG_FILE
 }

--- a/RHEL6_7/storage/lvm2-cluster/check
+++ b/RHEL6_7/storage/lvm2-cluster/check
@@ -2,7 +2,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 
 # Check if any of lvm cluster services are enabled.
 if service_is_enabled "clvmd"; then

--- a/RHEL6_7/storage/lvm2-services/check
+++ b/RHEL6_7/storage/lvm2-services/check
@@ -2,7 +2,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 
 POSTUPGRADE_DIR=$VALUE_TMP_PREUPGRADE/postupgrade.d/lvm2-services
 POSTUPGRADE_UNIT_LIST=units_to_enable

--- a/RHEL6_7/system/KrbMigration/check
+++ b/RHEL6_7/system/KrbMigration/check
@@ -5,8 +5,8 @@ check_applies_to "krb5-server"
 
 #END GENERATED SECTION
 
-# This check can be used if you need root privilegues
-check_root
+
+
 
 KRB_SYSCONFIG_FILE=/etc/sysconfig/krb5kdc
 

--- a/RHEL6_7/system/java/check
+++ b/RHEL6_7/system/java/check
@@ -134,7 +134,7 @@ check_java_gcj() {
     "Java applications compiled by GCJ will not work. Update your" \
     "Java applications to be sure that they run with OpenJDK" \
     "version 7 or 8."
-  set_result $RESULT_FAILED
+  set_result $RESULT_FAIL
 }
 
 
@@ -152,7 +152,7 @@ check_java6() {
       "If it is possible, remove OpenJDK 6" \
       "before you upgrade to Red Hat Enterprise Linux 7."
     log_high_risk "The $pkg_old_java package is installed, but it is not supported for upgrades."
-    set_result $RESULT_FAILED
+    set_result $RESULT_FAIL
 
     # at least we back up config files
     old_jvmdir=$(get_jvm_dir "$pkg_old_java")

--- a/RHEL6_7/system/polkit/check
+++ b/RHEL6_7/system/polkit/check
@@ -4,7 +4,7 @@
 #END GENERATED SECTION
 
 rm -f solution.txt
-check_root
+
 POLKIT_BACKUP_DIR="$VALUE_TMP_PREUPGRADE/polkit_conf"
 
 echo \

--- a/RHEL6_7/system/requirements/check
+++ b/RHEL6_7/system/requirements/check
@@ -3,7 +3,7 @@
 . /usr/share/preupgrade/common.sh
 #END GENERATED SECTION
 
-check_root
+
 
 NLOGICAL_CPU=$(nproc)
 ARCH=$(arch)

--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -14,7 +14,7 @@ if [[ -d "$TUNED_DIR" ]]; then
     sed -i s/POSTUPGRADE_DIR/\$POSTUPGRADE_TUNED_DIR/g solution.txt
     cp -Rv $TUNED_DIR/* $POSTUPGRADE_TUNED_DIR
     log_medium_risk "Tuned profiles were detected in the $TUNED_DIR directory. See the tuned-adm and tuned-profiles man pages for more information."
-    exit $RESULT_FAILED
+    exit $RESULT_FAIL
 fi
 
 exit $RESULT_NOT_APPLICABLE

--- a/RHEL6_7/usrmgmt/DangerousRanges/check
+++ b/RHEL6_7/usrmgmt/DangerousRanges/check
@@ -74,12 +74,12 @@ Your system contains UIDs or GIDs in the range 500 - 999. Therefore, the Red Hat
 " >>solution.txt
 
 result=0
-[ $founderror -eq 1 ] && result=$RESULT_FAILED
+[ $founderror -eq 1 ] && result=$RESULT_FAIL
 rhelup_preupgrade_hookdir="$VALUE_TMP_PREUPGRADE/preupgrade-scripts"
 [ $logindefs -eq 1 ] &&
  $(grep "/etc/login.defs" $VALUE_CONFIGCHANGED >/dev/null || $(mkdir -p "$rhelup_preupgrade_hookdir" && install -m755 fixlogindefs.sh "$rhelup_preupgrade_hookdir"/ )) &&
  result=$RESULT_FIXED
-[ $founderror -eq 1 ] && result=$RESULT_FAILED
+[ $founderror -eq 1 ] && result=$RESULT_FAIL
 [ $result -gt 0 ] && exit $result
 
 #no issues found, so remove solution text

--- a/RHEL6_7/usrmgmt/ypserv/makefile_config/check
+++ b/RHEL6_7/usrmgmt/ypserv/makefile_config/check
@@ -25,7 +25,7 @@ Fixing the ${CONFIG_FILE} file failed. You might have wrong MINUID/MINGID
 definitions in that file, and YPPUSH_ARGS might be missing there.
 EOF
     log_high_risk "${PROBLEM_DESC}"
-    exit $RESULT_FAILED
+    exit $RESULT_FAIL
 else
     log_debug "Fixing the ${CONFIG_FILE} file succeeded."
     echo "

--- a/RHEL6_7/usrmgmt/ypserv/maps_dbm/check
+++ b/RHEL6_7/usrmgmt/ypserv/maps_dbm/check
@@ -10,7 +10,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 
 . ../common.sh
 
@@ -36,4 +36,4 @@ EOF
 
 solution_file "$PROBLEM_SOLUTION"
 
-exit $RESULT_FAILED
+exit $RESULT_FAIL

--- a/RHEL6_7/usrmgmt/ypserv/max_uid_gid/check
+++ b/RHEL6_7/usrmgmt/ypserv/max_uid_gid/check
@@ -14,7 +14,7 @@
 
 #END GENERATED SECTION
 
-check_root
+
 
 . ../common.sh
 


### PR DESCRIPTION
The new API for modules has been changed:
 -- removed $RESULT_FAILED (only $RESULT_FAIL remains)
 -- removed check_root that is obsoleted

Fixes: #2