### PR TITLE
Remove obsolete and possibly confusing comments

### DIFF
--- a/RHEL6_7/networking/postfix/check
+++ b/RHEL6_7/networking/postfix/check
@@ -24,26 +24,6 @@ CONFIG_FILE="/etc/postfix/main.cf"
 mkdir -p $VALUE_TMP_PREUPGRADE/cleanconf/$(dirname $CONFIG_FILE)
 cp $CONFIG_FILE $VALUE_TMP_PREUPGRADE/cleanconf/$CONFIG_FILE
 
-
-# Now check your configuration file for options
-# and for other stuff related with configuration
-
-# If configuration can be used on target system (like RHEL7 in case of RHEL6_7)
-# the exit should be RESULT_PASS
-
-# If configuration can not be used on target system (like RHEL 7 in case of RHEL6_7)
-# scenario then result should be RESULT_FAILED. Correction of 
-# configuration file is provided either by solution script
-# or by postupgrade script located in $VALUE_TMP_PREUPGRADE/postupgrade.d/
-
-# if configuration file can be fixed then fix them in temporary directory
-# $VALUE_TMP_PREUPGRADE/$CONFIG_FILE and result should be RESULT_FIXED
-# More information about this issues should be described in solution.txt file
-# as reference to KnowledgeBase article.
-
-# postupgrade.d directory from your content is automatically copied by
-# preupgrade assistant into $VALUE_TMP_PREUPGRADE/postupgrade.d/ directory
-
 #workaround to openscap buggy missing PATH
 export PATH=$PATH:/usr/bin
 

--- a/RHEL6_7/networking/sendmail/check
+++ b/RHEL6_7/networking/sendmail/check
@@ -24,26 +24,6 @@ CONFIG_FILE="/etc/sysconfig/sendmail"
 mkdir -p $VALUE_TMP_PREUPGRADE/cleanconf/$(dirname $CONFIG_FILE)
 cp $CONFIG_FILE $VALUE_TMP_PREUPGRADE/cleanconf/$CONFIG_FILE
 
-
-# Now check your configuration file for options
-# and for other stuff related with configuration
-
-# If configuration can be used on target system (like RHEL7 in case of RHEL6_7)
-# the exit should be RESULT_PASS
-
-# If configuration can not be used on target system (like RHEL 7 in case of RHEL6_7)
-# scenario then result should be RESULT_FAILED. Correction of 
-# configuration file is provided either by solution script
-# or by postupgrade script located in $VALUE_TMP_PREUPGRADE/postupgrade.d/
-
-# if configuration file can be fixed then fix them in temporary directory
-# $VALUE_TMP_PREUPGRADE/$CONFIG_FILE and result should be RESULT_FIXED
-# More information about this issues should be described in solution.txt file
-# as reference to KnowledgeBase article.
-
-# postupgrade.d directory from your content is automatically copied by
-# preupgrade assistant into $VALUE_TMP_PREUPGRADE/postupgrade.d/ directory
-
 #workaround to openscap buggy missing PATH
 export PATH=$PATH:/usr/bin
 

--- a/RHEL6_7/networking/squid/check
+++ b/RHEL6_7/networking/squid/check
@@ -21,26 +21,6 @@ CONFIG_FILE="/etc/squid/squid.conf"
 mkdir -p $VALUE_TMP_PREUPGRADE/cleanconf/$(dirname $CONFIG_FILE)
 cp $CONFIG_FILE $VALUE_TMP_PREUPGRADE/cleanconf/$CONFIG_FILE
 
-
-# Now check your configuration file for options
-# and for other stuff related with configuration
-
-# If configuration can be used on target system (like RHEL7 in case of RHEL6_7)
-# the exit should be RESULT_PASS
-
-# If configuration can not be used on target system (like RHEL 7 in case of RHEL6_7)
-# scenario then result should be RESULT_FAILED. Correction of 
-# configuration file is provided either by solution script
-# or by postupgrade script located in $VALUE_TMP_PREUPGRADE/postupgrade.d/
-
-# if configuration file can be fixed then fix them in temporary directory
-# $VALUE_TMP_PREUPGRADE/$CONFIG_FILE and result should be RESULT_FIXED
-# More information about this issues should be described in solution.txt file
-# as reference to KnowledgeBase article.
-
-# postupgrade.d directory from your content is automatically copied by
-# preupgrade assistant into $VALUE_TMP_PREUPGRADE/postupgrade.d/ directory
-
 #workaround to openscap buggy missing PATH
 export PATH=$PATH:/usr/bin
 ret=$RESULT_INFORMATIONAL

--- a/RHEL6_7/services/httpd/check
+++ b/RHEL6_7/services/httpd/check
@@ -18,25 +18,6 @@ cp --parents -ar $CONFIG_PATH $VALUE_TMP_PREUPGRADE/dirtyconf/
 # for chack if mod_ldap should be installed by postupgrade script
 TMP_FLAG_FILE=$(mktemp .BumpedLibsXXX --tmpdir=/tmp)
 
-# Now check your configuration file for options
-# and for other stuff related with configuration
-
-# If configuration can be used on target system (like RHEL7 in case of RHEL6_7)
-# the exit should be RESULT_PASS
-
-# If configuration can not be used on target system (like RHEL 7 in case of RHEL6_7)
-# scenario then result should be RESULT_FAILED. Correction of
-# configuration file is provided either by solution script
-# or by postupgrade script located in $VALUE_TMP_PREUPGRADE/postupgrade.d/
-
-# if configuration file can be fixed then fix them in temporary directory
-# $VALUE_TMP_PREUPGRADE/$CONFIG_PATH and result should be RESULT_FIXED
-# More information about this issues should be described in solution.txt file
-# as reference to KnowledgeBase article.
-
-# postupgrade.d directory from your content is automatically copied by
-# preupgrade assistant into $VALUE_TMP_PREUPGRADE/postupgrade.d/ directory
-
 #workaround to openscap buggy missing PATH
 export PATH=$PATH:/usr/bin
 ret=$RESULT_INFORMATIONAL


### PR DESCRIPTION
These comments come from template and are not necessary in the modules
(actually they are rather confusing).