### PR TITLE
system/grub: install grub2 by post-upgrade script (#1497731)

### DIFF
--- a/RHEL6_7/system/grub/postupgrade.d/postupgrade-grub.sh
+++ b/RHEL6_7/system/grub/postupgrade.d/postupgrade-grub.sh
@@ -4,4 +4,15 @@ FILE_NAME="splash.xpm.gz"
 if [[ -f "$FILE_NAME" ]]; then
     cp -n $FILE_NAME /boot/grub/$FILE_NAME
 fi
+
+# exit when grub2 rpm is installed
+rpm -q grub2 >/dev/null 2>&1 && exit 0
+
+echo >&2 "Info: Install the grub2 package."
+yum -y install grub2 || {
+  echo >&2 "Warning: The grub2 has not been installed. Install it manually."
+  exit 1
+}
+
 exit 0
+


### PR DESCRIPTION
On RHEL 7.4+ system the grub2 rpm doesn't set *Obsoletes* on the grub
package. As consequence the grub2 is not installed automatically
during *upgrade* phase and need to be installed by post-upgrade
script.

Fixes #23