### PR TITLE
Bump to version 0.7.0

### DIFF
--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -4,7 +4,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
 Name:           preupgrade-assistant-el6toel7
-Version:        0.6.71
+Version:        0.7.0
 Release:        1%{?dist}
 Summary:        Set of modules created for upgrade to Red Hat Enterprise Linux 7
 Group:          System Environment/Libraries
@@ -14,14 +14,15 @@ Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{pkg_name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-Requires:       preupgrade-assistant >= 2.4.4
-BuildRequires:  preupgrade-assistant-tools >= 2.4.4
+Requires:       preupgrade-assistant >= 2.5.0
+BuildRequires:  preupgrade-assistant-tools >= 2.5.0
 
 # static data are required by our modules & old contents
 # are obsoleted by this package
 Obsoletes:      preupgrade-assistant-contents < 0.6.41-6
 Provides:       preupgrade-assistant-contents = %{version}-%{release}
 Requires:       preupgrade-assistant-el6toel7-data
+
 
 ############################
 # Per module requirements #

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
-Version 0.6.71
+Version 0.7.0
 DataVersion 0
 6.9-7.4


### PR DESCRIPTION
- modules now require preupgrade-assistant* (PA) packages v2.5.0+
- modules provides new capability preupgrade-assistant-system-upgrade
  that will be used by the redhat-upgrade-tool in future
- removed pointless dependency on redhat-upgrade-tool
- polishing of texts
- removed keys *check_script* and *solution* from INI file of each
  module
- added new informational module fot SAMBA
- added init script that initialize environment before the modules
  are processed; it is processed by the PA automatically when the
  init file exists and it is executable
- added file properties.ini with additional metadata for the PA
  about set of modules
- modified modules to not use deprecated functionality from PA API
- modified openssh/sysconfig module to remove astray output and provide
  cleaner information with relevant risk level
- ensure the grub2 is isntalled on upgraded system