### PR TITLE
Support for assessment format version

### DIFF
--- a/RHEL6_7/properties.ini
+++ b/RHEL6_7/properties.ini
@@ -1,3 +1,4 @@
 [preupgrade-assistant-modules]
 src_major_version=6
 dst_major_version=7
+assessment_format_version=0.1


### PR DESCRIPTION
We want to make sure that the Red Hat Upgrade Tool and the Preupgrade Assistant (the other tools) will be able to "understand" the data generated by the Preupgrade Assistant Modules (the Modules). For this purpose the Modules will provide a new key inside the _properties.ini_ file: `ast_fmt_version`. It's value will contain version in X.Y format, with semantic:
- X will be bumped when "something" in the Modules changes in such a way that the other tools need to be updated to cope with the change,
- Y will be bumped, when just "something" new has been added to the Modules, but the other tools do not require any change because of this addition in order to work as expected with the data generated by the Modules.

The "something" will be specified later in docs. Currently we can say, that it is everything that is parsed, read, required by the other tools for their correct functionality, but it doesn't include e.g. specific pre-upgrade or post-upgrade scripts or texts in the Preupgrade Assistant report.
  ...
But we can say, that it includes e.g.:
  dirtyconf directory
  hooks directory
  kickstart/RHRHEL7rpmlist_replaced file; that is used when kickstart
                                          is generated
  ...

Resolves #31