### PR TITLE
Remove links from the risk logs

### DIFF
--- a/RHEL6_7/packages/NonRHSignedPkg/check
+++ b/RHEL6_7/packages/NonRHSignedPkg/check
@@ -26,5 +26,5 @@ get_dist_non_native_list > "$KICKSTART_DIR/nonrhpkgs"
 }
 
 #We detected some non-redhat package
-log_high_risk "We detected some packages not signed by Red Hat. You can find the list in the [link:/root/preupgrade/kickstart/nonrhpkgs] file. Handle them yourself."
+log_high_risk "We detected some packages not signed by Red Hat. You can find the list in the /root/preupgrade/kickstart/nonrhpkgs file. Handle them yourself."
 exit $RESULT_FAIL

--- a/RHEL6_7/services/openssh/sshd/check
+++ b/RHEL6_7/services/openssh/sshd/check
@@ -65,7 +65,7 @@ If you want to fix the config file yourself, type:
 
 For more information about AuthorizedKeysCommandUser, see the SSHD_CONFIG(5) man page.
 "
-        log_slight_risk "AuthorizedKeysCommandUser will be added into [link:cleanconf/$SSHD_CONFIG_FILE]."
+        log_slight_risk "AuthorizedKeysCommandUser will be added into $VALUE_TMP_PREUPGRADE/cleanconf/$SSHD_CONFIG_FILE."
 
 	echo 'AuthorizedKeysCommandUser %u' >> $VALUE_TMP_PREUPGRADE/cleanconf/$SSHD_CONFIG_FILE && RESULT=$RESULT_FIXED
     fi


### PR DESCRIPTION
Logs are processed just as raw strings and are not modified at all. So use of constructions like
  [link:url]
is wrong here and it should not be used.