### PR TITLE
system/python: handle ownership of directories by more rpms

### DIFF
--- a/RHEL6_7/system/python/check
+++ b/RHEL6_7/system/python/check
@@ -10,17 +10,30 @@ if [ -f "$PYTHON_DIRS" ]; then
     rm -f $PYTHON_DIRS
 fi
 
+any_native_pkg_detected() {
+    #
+    # Accept 1 argument with set of rpms. Return 0 when any of them is
+    # native, otherwise 1.
+    #
+    for pkg in $1;
+    do
+        is_dist_native $(rpm -q --qf "%{NAME}" $pkg) && return 0
+    done
+
+    return 1
+}
+
 FOUND=0
-for py_dir in `find -P /usr/lib*/python*/site-packages/* -maxdepth 0 -type d`
+for py_dir in $(find -P /usr/lib*/python*/site-packages/* -maxdepth 0 -type d)
 do
-    RPM=`rpm -qf $py_dir`
+    RPM=$(rpm -qf $py_dir)
     if [ $? -ne 0 ]; then
         log_slight_risk "$py_dir is not owned by an RPM package."
         FOUND=1
         continue
     fi
-    RPM_NAME=`rpm -q --qf "%{NAME}" $RPM`
-    is_dist_native "$RPM_NAME"
+
+    any_native_pkg_detected "$RPM"
     if [ $? -ne 0 ]; then
         log_slight_risk "$py_dir is owned by an RPM package that was not signed by Red Hat."
         FOUND=1


### PR DESCRIPTION
Previously in case a directory was owned by multiple rpms, script printed warning message with mismatched names of the pkgs. Now it is handled correctly and in case that the directory is owned at least by one native rpm.

refactoring: Replaced backticks by "$(...)"

Example of unwanted wrning message for two packages:
```
preupg.log.WARNING: Package python-backportspython-backports-ssl_match_hostname is not installed on Red Hat Enterprise Linux system.
```