### PR TITLE
Provide directory for third party modules.

### DIFF
--- a/RHEL6_7/3rdparty/group.ini
+++ b/RHEL6_7/3rdparty/group.ini
@@ -1,0 +1,2 @@
+[preupgrade]
+group_title = Third party modules

--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -85,7 +85,6 @@ install -d -m 755 $RPM_BUILD_ROOT%{_datadir}/preupgrade
 mv LICENSE $RPM_BUILD_ROOT%{_datadir}/doc/preupgrade-assistant-el6toel7/
 mv RHEL6_7-results $RPM_BUILD_ROOT%{_datadir}/preupgrade/RHEL6_7
 
-mkdir -p $RPM_BUILD_ROOT%{_datadir}/preupgrade/RHEL6_7/3rdparty
 rm -rf $RPM_BUILD_ROOT/%{_datadir}/preupgrade/common
 
 # General cleanup


### PR DESCRIPTION
We expect that third party modules will be located in the specific directory. In this case the chosen dirname is "3rdparty".

The SPEC file has been modified appropriately.

[0] https://github.com/upgrades-migrations/preupgrade-assistant/pull/348