### PR TITLE
initscripts/control: update preset file

### DIFF
--- a/RHEL6_7/system/initscripts/control/90-default.preset
+++ b/RHEL6_7/system/initscripts/control/90-default.preset
@@ -36,6 +36,7 @@ enable ladvd.service
 # Storage
 enable multipathd.service
 enable libstoragemgmt.service
+enable lvm2-lvmpolld.socket
 enable lvm2-monitor.*
 enable lvm2-lvmetad.*
 enable dm-event.*
@@ -54,10 +55,6 @@ enable qemu-guest-agent.service
 # https://bugzilla.redhat.com/show_bug.cgi?id=928726
 enable dnf-makecache.timer
 
-# https://bugzilla.redhat.com/show_bug.cgi?id=929403
-enable initial-setup-graphical.service
-enable initial-setup-text.service
-
 # https://bugzilla.redhat.com/show_bug.cgi?id=957135
 enable vmtoolsd.service
 
@@ -67,12 +64,16 @@ enable kdump.service
 #https://bugzilla.redhat.com/show_bug.cgi?id=1009970
 enable tuned.service
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1215645
+enable unbound-anchor.timer
+
 # Hardware
 enable gpm.*
 enable gpsd.*
 enable irqbalance.service
 enable lm_sensors.service
 enable mcelog.*
+enable microcode.service
 enable acpid.*
 enable smartd.service
 enable pcscd.socket
@@ -104,3 +105,34 @@ enable udisks2.service
 enable polkit.service
 enable packagekit-offline-update.service
 enable PackageKit.service
+
+# Initial Setup reconfiguration service
+enable initial-setup-reconfiguration.service
+
+# virtlog.service is sometimes used by VMs started by libvirt.service
+# Enable virtlog.socket to have it socket activated
+# https://bugzilla.redhat.com/show_bug.cgi?id=1325503
+enable virtlogd.socket
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1271839
+enable rhsmcertd.service
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1359645
+enable brandbot.*
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1493545
+enable rhel-autorelabel.service
+enable rhel-autorelable-mark.service
+enable rhel-configure.service
+enable rhel-dmesg.service
+enable rhel-domainname.service
+enable rhel-import-state.service
+enable rhel-loadmodules.service
+enable rhel-readonly.service
+
+## NOTE ##
+# The hypervfcopyd service isn't part of the preset file on RHEL 7.5 system
+# as it is enabled automatically when corresponding device is detected. But for
+# purposes of preupgrade report we keep it here to suppress unwanted message.
+enable hypervfcopyd.service
+


### PR DESCRIPTION
Update bundled preset file to newer one we expect will be used in RHEL 7.5. In addition add there hypervfcopy service as enabled even when it is not part of the preset file on target system. The service is enabled automatically when corresponding device is detected. This change suppress unwanted message in report.


Resolves #53 .