### PR TITLE
Merge specification of some modules

### DIFF
--- a/RHEL6_7/databases/mysql/configuration_changes/module_spec
+++ b/RHEL6_7/databases/mysql/configuration_changes/module_spec
@@ -1,0 +1,36 @@
+- applicable when mysql or (or and? not sure here about behaviour) mysql-libs
+  are installed - at least when any of them is installed, should be result
+  NOT_APPLICABLE (maybe if missing one of them, ask phracek about it)
+
+Backup and check config file /etc/my.cnf - and recusively all other config
+files which are included through directives "!include" and "!includedir"
+- if contains deprecated, removed or unsupported options/settings:
+
+a) "plugin-load=innodb=" and doesn't contains "ignore-builtin-innodb":
+ - print relevant info (contains relevant options) in solution file
+ - log medium risk - file + message
+
+b) "innodb_file_io_threads":
+ - print relevant info in solution file
+ - log high risk - file + message
+
+c) "language\s*="
+ - print relevant info in solution file
+ - log high risk - file + message
+
+d) "log-bin-trust-routine-creators" or "table_lock_wait_timeout":
+ - print relevant info in solution file
+ - log high risk - file + message
+
+also try comment out these lines in backuped files and create 2 lists of files
+which contains:
+ - backuped files where all mentioned options are commented out
+ - backuped files wehre at least one mentioned option is not commented out
+
+On the end, print these two lists and append some recommendation, what he
+should do with files above (when result FAILED).
+
+Exit result:
+ - INFORMATIONAL - mentioned options weren't found
+ - FAILED - at least one of them was found
+ - NOT_APPLICABLE (above)

--- a/RHEL6_7/networking/bind/bind-chroot/module_spec
+++ b/RHEL6_7/networking/bind/bind-chroot/module_spec
@@ -1,0 +1,38 @@
+not_applicable:
+
+     if package bind-chroot is not installed on the source system
+
+     actions: 
+              No action. preupgrade-assistant does not run the
+              module
+
+needs_inspection
+
+     if package bind-chroot is installed on the source system,
+     but ROOTDIR directive is not specified in /etc/sysconfig/named
+
+     actions: 
+              General information about the changes in the way
+              BIND9 is running in chroot environment between
+              Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7
+              is printed, along with link to the Knowledgebase article
+              explaining it in detail.
+
+needs_action
+      
+     if package bind-chroot is installed on the source system, 
+     and ROOTDIR directive is specified in /etc/sysconfig/named
+
+     actions :
+              General information about the changes in the way
+              BIND9 is running in chroot environment between
+              Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7
+              is printed, along with link to the Knowledgebase article
+              explaining it in detail.
+
+              Relevant configuration files are backed up.
+
+              The message is printed for informing user about total
+              size of the chrooted zone files, as well as how to 
+              back them up manually. List of existing chrooted zone 
+              files is $zonefile_list file, which is backed up.

--- a/RHEL6_7/networking/bind/configuration/module_spec
+++ b/RHEL6_7/networking/bind/configuration/module_spec
@@ -1,0 +1,39 @@
+passed:
+  - no problem (list below) has been found
+
+informational:
+  - "tcp-listen-queue" in the options statement is set and it is less then 10
+      -> solution + log slight risk
+  - "zone-statistics" in the options statement is set with value "yes" or "no"
+      -> solution + log slight risk
+
+fixed:
+  - (**) "pid-file" is not set with the "/run/named/named.pid" path
+    "session-keyfile" is not set with the "/run/named/session.key" path
+    already
+    -> solution + log info
+    -> the file that contains the option section is stored under the [0] dir
+       and contains both statements with the values mentioned above
+    -> it is applied on the target system automatically
+
+neees_inspection:
+  - a slave zone without "masterfile-format" statement is defined
+      -> solution + log medium risk
+
+needs_action:
+  - empty zones are enabled (the "empty-zones-enable yes" inside the options
+    statement) and there is enabled empty zone, that conflicts with built-in
+    list of empty zones
+      -> solution + log high risk
+
+
+error:
+  - options statement has not been found
+  - configuration is broken
+  - any configuration files cannot be opened for reading
+  - main configuration file is missing
+
+NOTE: priority is sorted from the top to down (error has the highest prio),
+      result with lower prio cannot replace result with higher prio
+
+[0] /root/preupgrade/cleanconf/

--- a/RHEL6_7/packages/ObsoletedPackages/module_spec
+++ b/RHEL6_7/packages/ObsoletedPackages/module_spec
@@ -1,0 +1,81 @@
+terminology: for correct understanding of the text below and content:
+ - obsoleted = partially replaced by pkg(s) = replacement is not compatible
+   - get from static data
+=============================================================================
+Description for testing:
+
+a) when a native package is obsoleted on RHEL 7 system, it is available
+   inside base repository and isn't required by any non-native package
+   - add info into the solution file
+   - add line in PSV format (below) into [1]
+
+b) like a) but it is available inside different repository
+   - add info into the solution file with message about different channel
+   - add line in PSV format into [3]
+   - when the package is in same (equivalent) repository on old and new system
+     -> log_medium_risk about package inside not-base channel
+   - when the package is inside different channel on new system
+     -> log_medium_risk -> like above but different msg, which contains info
+        like "moved to ..."
+
+c) like a) but it is required by at least one non-native package
+   - add info into the solution file with message about non-native packages
+     which require this one (see below)
+   - add line in PSV format into [2]
+   - log_high_risk about that, including message like:
+     "(required by Non Red Hat signed package(s):pkg1 pkg2 ... pkgN)"
+
+d) combination of b) + c), just for clarification
+   - log_high_risk
+   - add line in PSV format into [4]
+
+----------------
+e) when any b) or d) package exists and migrate mode is enabled
+   (unsupported scenario yet, but for completeness)
+   - print info relevant for migration scenario with list of channels (names),
+     that user needs covered by subscriptions to get needed repositories for
+     all packages inside not-base repositories
+   - NOTE: used path to install_rpmlist.sh [3] is different in system installed
+           by kickstart, but it is not supported yet and path is not provided
+           by PA API yet
+
+*) append info about kickstart files which this content could create into [6]
+
+-------------
+Format of files generated for kickstart:
+<pkgname>|<required_by_not_native_pkg[ pkg]*>|<obsoleted_by_pkg[ pkg]*>|<repo-id>
+# + supported comment lines like this one
+
+e.g. (just imagined):
+grub||grub2|
+tomcat6-javadoc||tomcat-javadoc|rhel-7-server-optional-rpms
+pkgA|pkg1 pkg2 pkg3|pkgB1 pkgB2|rhel...
+
+- repo-id is empty when it is available in base channel [1,2]
+
+-------------
+Exit results:
+ - PASS - all installed native packages are not obsoleted by any package
+          on RHEL 7
+ - FAIL - found at least one installed native package which is obsoleted
+          on RHEL 7
+ - ERROR - $VALUE_RPM_RHSIGNED or $COMMON_DIR doesn't exist (+ log_error)
+         - or one of these tmp files wasn't created or is not readable
+           (+ log_error):
+             $ObsoletedPkgs $MoveObsoletedPkgs $NotBasePkgs
+
+-------------
+See [7] - separator ";", 3rd column contains repo-id, 4th "name of channel".
+- important files inside [0] includes *obsoleted* in name
+
+[0] /root/preupgrade/RHEL6_7/common
+[1] /root/preupgrade/kickstart/RHRHEL7rpmlist_obsoleted
+[2] /root/preupgrade/kickstart/RHRHEL7rpmlist_obsoleted-required
+[3] /root/preupgrade/kickstart/RHRHEL7rpmlist_obsoleted-notbase
+[4] /root/preupgrade/kickstart/RHRHEL7rpmlist_obsoleted-required-notbase
+
+[5] /root/preupgrade/*/noauto_postupgrade.d/install_rpmlist.sh
+    (may will be inside kickstart, may not, depends on API,
+     see $NOAUTO_POSTUPGRADE_D)
+[6] /root/preupgrade/kickstart/README
+[7] /root/preupgrade/RHEL6_7/common/default_nreponames

--- a/RHEL6_7/packages/ReplacedPackages/module_spec
+++ b/RHEL6_7/packages/ReplacedPackages/module_spec
@@ -1,0 +1,105 @@
+=============================================================================
+terminology: for correct understanding of the text below and content:
+ - replaced = completely replaced by pkg(s) = replacement is compatible
+=============================================================================
+Description for testing:
+
+a) when a native package is replaced on RHEL 7 system, it is available
+   inside base repository and isn't required by any non-native package
+   - add info into the solution file
+   - add line in PSV format (below) into [1]
+
+b) like a) but it is available inside different repository
+   - add info into the solution file with message about different channel
+   - add line in PSV format into [2]
+   - when the package is in same (equivalent) repository on old and new system
+     -> log_high_risk about package inside not-base channel
+   - when the package is inside different channel on new system
+     -> log_high_risk -> like above but different msg, which contains info
+        like "moved to ..."
+
+c) like a) but it is required by at least one non-native package
+   - add info into the solution file with message about non-native packages
+     which require this one (see below)
+   - add line in PSV format into [1]
+   - log_slight_risk about that, including message like:
+     "(required by Non Red Hat signed package(s):pkg1 pkg2 ... pkgN)"
+
+d) combination of b) + c), just for clarification
+   - log_high_risk
+   - add line in PSV format into [2]
+
+----------------
+e) when any b) or d) package exists, print info about replacements inside not
+   base repositories
+   - and when upgrade mode is enabled, print info that only packages from
+     optional repository is supported (I guess that here should be base and
+     optional)
+     -> and when there is a package from optional repository print info how
+        can be optional repository added to redhat-upgrade-tool
+
+f) when any b) or d) package exists and migrate mode is enabled
+   (unsupported scenario yet, but for completeness)
+   - print info relevant for migration scenario with list of channels (names),
+     that user needs covered by subscriptions to get needed repositories for
+     all packages inside not-base repositories
+   - NOTE: used path to install_rpmlist.sh [3] is different in system
+           installed by kickstart, but it is not supported yet and path is not
+           provided by PA API yet
+
+g) when upgrade mode is enabled, create postupgrade script [8], which ensures
+   that all replacements will be installed and old replaced packages will be
+   removed
+   - important for installed native packages which are part of lists [4,5]
+
+*) append info about kickstart files which this content could create into [6]
+
+-------------
+Format of files generated for kickstart:
+<pkgname>|<required_by_not_native_pkg[ pkg]*>|<replqced_by_pkg[ pkg]*>|<repo-id>
+# + supported comment lines like this one
+
+e.g. (just imagined):
+grub||grub2|
+tomcat6-javadoc||tomcat-javadoc|rhel-7-server-optional-rpms
+pkgA|pkg1 pkg2 pkg3|pkgB1 pkgB2|rhel...
+
+- repo-id is empty when it is available in base channel [1]
+
+-------------
+Exit results:
+ - PASS - all installed native packages are not replaced by any package
+          on RHEL 7
+ - FIXED - all replaced packages are provided ba replacements and all
+           replacements are available in base repository (and at least one
+           exists)
+ - FAIL - found at least one installed native package which is replaced
+          on RHEL 7 and replacement doesn't provide original package or is
+          not available inside base repository
+ - ERROR - one of these file (below) doesn't exist or are not readable
+           (+ log_error):
+             $COMMON_DIR/ProvidesonlyMissing
+             $COMMON_DIR/BothMissing
+             $COMMON_DIR/default_nreponames"
+
+         - or one of these tmp files wasn't created or is not readable
+           (+ log_error):
+             $ReplacedPkgs $MoveReplacedPkgs $NotBasePkgs
+- $COMMON_DIR  [0]
+
+-------------
+See [7] - separator ";", 3rd column contains repo-id, 4th "name of channel".
+- important files inside [0] includes *obsoleted* in name
+
+[0] /root/preupgrade/RHEL6_7/common
+[1] /root/preupgrade/kickstart/RHRHEL7rpmlist_replaced
+[2] /root/preupgrade/kickstart/RHRHEL7rpmlist_replaced-notbase
+
+[3] /root/preupgrade/*/noauto_postupgrade.d/install_rpmlist.sh
+    (may will be inside kickstart directory, may not, depends on API,
+     see $NOAUTO_POSTUPGRADE_D)
+[4] /root/preupgrade/RHEL6_7/common/ProvidesonlyMissing
+[5] /root/preupgrade/RHEL6_7/common/BothMissing
+[6] /root/preupgrade/kickstart/README
+[7] /root/preupgrade/RHEL6_7/common/default_nreponames
+[8] /root/preupgrade/postupgrade.d/replacedpkg/fixreplaced.sh

--- a/RHEL6_7/packages/notbase-channel/module_spec
+++ b/RHEL6_7/packages/notbase-channel/module_spec
@@ -1,0 +1,96 @@
+Brief summary of changes:
+- content was renamed to 'notbase-channel'
+- used log_error instead of log_high_risk before exit_error
+- removed dependency on yum - instead of check of enabled repositories,
+  check installed packages from optional repository and filter out packages
+  which will be removed or moved to base repository on new system
+- changed content title and description
+- *debug packages are ignored totally
+- print info about packages which are not part of base channel
+- print info about needed 'provides' from subscriptions - under
+  these provides should be available repositories which contains
+  mentioned packages
+- uses the newest API provided by preupgrade-assistant
+- modified texts - added info about needed subcriptions for relevant packages
+- kickstart files use CVS format now; added info about repo-id
+- all files generated for kickstart starts with "RHRHEL7rpmlist_kept"
+- files for kickstart contain only relevant information for the system
+  - previously were included even packages which were not installed inside
+    'RHRHEL7rmplist_kept' file
+=============================================================================
+Description for testing:
+a) create list of native installed packages available in base repository on RHEL 7 [1]
+   with format described below (second column is always empty, because it is not important
+   information in this case, but can be simply added by two-line change if we want)
+   - these packages should be installed always on new system
+
+b) when a native package is available on RHEL 7 system but not inside base repository
+   - when the package is in same (equivalent) repository on old and new system
+     -> log high risk about package sinside channel (in case of optional channel is used just
+        name "Optional" channel for all variants)
+   - when the package is inside different repository on new system
+     -> similar as above, just different log, which contains info like "moved to ..."
+   - print info in remediation instructions with info about channel:
+     pkg (<channel> channel)
+     pkg (optional channel)
+   - when the package is required by non-native package(s), additionaly insert info message like
+     "(required by Non Red Hat signed package(s):pkg1 pkg2 ... pkgN)"
+     -> used in all cases of b) above
+   - always - store info into [2] with format described below
+
+c) when any b) package exists and upgrade mode is enabled
+   - print info/instructions for using of redhat-upgrade-tool (supported just base and optional)
+   - when any package is in addon (not int base or optional channel), log high risk that other
+     channels are not supported for inplace upgrade
+d) when any b) package exists and migrate mode is enabled
+   (unsupported scenario yet, but for completeness)
+   - print info relevant for migration scenario with list of channels (names), that user needs
+     covered by subscriptions to get needed repositories for all not-base packages
+   - NOTE: used path to install_rpmlist.sh [3] is different in system installed by kickstart,
+           but it is not supported yet and path is not provided by PA API yet
+*) append info about kickstart files which this content could create into [4]
+-------------
+Format of files generated for kickstart:
+<pkgname>|<required_by_not_native_pkg[ pkg]*>|<pkgname_on_RH7>|<repo-id>
+# + supported comment lines like this one
+
+e.g. (just imagined):
+curl||curl|
+git-all||git-all|rhel-7-server-optional-rpms
+subversion-perl|some-pkg some-pkg2|subversion-perl|rhel-7-server-optional-rpms
+
+
+- repo-id is empty when it is available in base channel [1]
+- 1st nad 3rd columns are same because these packages are available on both systems
+
+-------------
+Exit results:
+ - PASS - all installed native packages are available inside base repository on RHEL 7
+ - FAIL - found at least one installed native package which is part of of other repositories on RHEL 7
+ - ERROR - $COMMON_DIR doesn't exist or doesn't contain 'default'* files
+           + log_error
+         - or one of these tmp files wasn't created or is not readable (+ log_error):
+           $AddonPkgs, $OptionalPkgs, $KeptBasePkgs, $DistNativePkgs
+
+-------------
+See [5] - separator ";", 3rd column contains repo-id, 4th "name of channel".
+See functions in check script [6] (it_s easier for description):
+  - print_base_files()
+       -> to get list of files which contain list of kept packages available
+          inside base repository of new system
+  - print_opt_file_list()
+       -> to get list of files which contain list of kept packages available
+          inside optional repository of new system
+  - print_addon_file_list()
+       -> to get list of files which contain list of kept packages available
+          inside not-base repositories of new system, excludes optional repository
+  --- all exclude *debug* repositories
+
+[0] /root/preupgrade/RHEL6_7/common
+[1] /root/preupgrade/kickstart/RHRHEL7rpmlist_kept
+[2] /root/preupgrade/kickstart/RHRHEL7rpmlist_kept-notbase
+[3] /root/preupgrade/*/noauto_postupgrade.d/install_rpmlist.sh
+    (may will be inside kickstart, may not, depends on API, see $NOAUTO_POSTUPGRADE_D)
+[4] /root/preupgrade/kickstart/README
+[5] /root/preupgrade/RHEL6_7/common/default_nreponames
+[6] /usr/share/preupgrade/RHEL6_7/packages/notbase-channel/check.sh

--- a/RHEL6_7/services/httpd/module_spec
+++ b/RHEL6_7/services/httpd/module_spec
@@ -1,0 +1,92 @@
+informational
+  - [0,4] uses (on target system deprecated) directives for access control
+    like "Order allow,deny", "Mutual-failure" (see [up])
+      -> solution text
+      - NOTES:
+            - for backward compatibility mod_access_compat.so is loaded
+              by default already, so it is not handled by the module itself
+            - I found that inside [5], but the directory is loaded only in case
+              is is included on the old machine - is there possible way,
+              that module will not be loaded on the target system?? (test)
+  - print diff between default configuration file [0] and the current one
+  - migration + httpd listen on non-default port (different from 80, 443)
+     -> solution text + slight risk
+     -> selinux is changed on the target system, so ports are usable
+     - NOTE**: should be that: log info + fixed?
+  - migration + service is disabled for all runlevels
+     -> solution + log info + service is disabled on target system
+     - NOTE**
+  - migration + services is enabled at least for one runlevel
+     -> solution + log info + service is enabled on the target system
+     - NOTE**
+
+result FIXED
+  - inside [0] is loaded
+      - any module from [1,2];
+          -> print solution text with list of relevant modules
+          -> relevant lines are removed from the file on the target system
+      - speling_module and CheckSpelling is used inside [0,4]
+          -> solution text
+          -> module is enabled (loaded) on target system
+      - usertrack_module and any Cookie is used inside [0,4]
+          -> solution text
+          -> module is enabled (loaded) on target system
+  - [0] contains "Include conf.modules.d/*.conf"
+      -> solution text
+      -> the directory is still included on the target system
+  - for each module below separately - when module is loaded inside [0,4] but it is not used:
+      perl_module
+      dnssd_module
+      auth_pgsql_module
+      mysql_auth_module
+          -> solution text
+          -> module is not loaded on target system
+  - httpd.event is used inside [0,4]
+      -> solution text
+      -> mpm_even is loaded on the target system
+  - httpd.worker is used inside [0,4]
+      -> solution text
+      -> mpm_worker is loaded on the target system
+  - "SSLMutex default" inside [0,4]
+      -> solution text
+      -> lines are commented out on the target system
+  - "SSLPassPhraseDialog    builtin" inside [0,4]
+      -> solution text
+      -> text is replaced (on the target system) by:
+         "SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog"
+  - SSLSessionCache    shmcb:/var/cache/mod_ssl/scache
+      -> solution text
+      -> text is replaced (on the target system) by:
+         "shmcb:/run/httpd/sslcache"
+
+
+need_inspection
+    - ldap_module and LDAP or AuthLDAP is used inside [0,4]
+          -> solution text + medium risk
+          -> post-upgrade script tries install package mod_ldap package from
+             Optional channel (whether Optional channel is not available during
+             upgrade/migration, fail is expected)
+  - for each module below separately - when module is loaded inside [0,4] and it is used:
+      perl_module
+      dnssd_module
+      auth_pgsql_module
+      mysql_auth_module
+          -> solution text + medium risk
+          -> module is still loaded on the target system
+  - when any of these directives is used:
+      AuthzLDAPAuthoritative
+      AuthzDBDAuthoritative
+      AuthzDBMAuthoritative
+      AuthzGroupFileOwnerAuthoritative
+      AuthzGroupFileAuthoritative
+      AuthzUserAuthoritative
+      AuthzOwnerAuthoritative
+
+[0] /etc/httpd/conf/httpd.conf
+[1] /usr/share/preupgrade/RHEL6_7/services/httpd/removed_modules
+[2] /usr/share/preupgrade/RHEL6_7/services/httpd/default_modules
+[3] /usr/share/preupgrade/RHEL6_7/services/httpd/conf.d/
+[4] /usr/share/preupgrade/RHEL6_7/services/httpd/conf.d/*.conf
+[5] /etc/httpd/conf.modules.d/00-base.conf
+
+[up] https://httpd.apache.org/docs/2.4/upgrading.html

--- a/RHEL6_7/services/openssh/sshd/module_spec
+++ b/RHEL6_7/services/openssh/sshd/module_spec
@@ -1,0 +1,99 @@
+==============================================================================
+The module specification:
+==============================================================================
+
+Root cause
+----------
+SSHD_CONFIG on RHEL 6 is not compatible with RHEL 7. The configuration file
+has to be checked and fixed (when it is possible) otherwise admin will not be
+able to connect using SSH after upgrade.
+
+
+short story long:
+-----------------
+The module is applied when openssh-server is installed. Unless [0] contains any
+of these options:
+    - RequiredAuthentications1
+    - RequiredAuthentications2
+    - AuthorizedKeysCommand
+result is PASS as used configuration is compatible with one that can be used
+on RHEL 7.
+
+In case the RequiredAuthentications1 is detected, inspection is
+recommended (slight risk + exit fail) as the option is used for unsupported
+protocol SSH-1. Result file has to be stored as [2] and with corresponding line
+commented out.
+
+In case that RequiredAuthentications2 is detected, the option should be
+replaced by AuthenticationMethods in the modified config [1 or 2]. In case
+the replacement fails, manual action is required and file is definitely stored
+as [2] (high risk + exit fail).
+
+When the AuthorizedKeysCommand is detected and when AuthorizedKeysCommandRunAs
+    a) is detected, replace the second one by AuthorizedKeysCommandUser
+    b) is missing, add line 'AuthorizedKeysCommandUser %u'
+in [1 or 2]. When anything fails, the (modified) config file is stored as [2].
+
+In case the RequiredAuthentications1 is not detected and no fail is detected
+the file is stored as [1] with result fixed. When fixing of file fails, it is
+always stored as [2] and manual action is requested.
+
+In case the copying of the file fails, error is logged and then scripts exits
+with error result.
+
+In case the script doesn't end with error result, postupgrade script
+  a) do nothing when [1] exists
+  b) back up [0] as [3] and replace it by [2]
+In case of (b), do additionaly one more time scan of the [0] and replace/remove
+relevant options when they occurs. Just to be sure, the final file doesn't
+contain any of these.
+
+
+long story short:
+-----------------
+
+INST | RA1 | RA2 | AKC | AKCRU | BAK_FAIL | FIX_FAIL || BAK | RESULT
+=====================================================||====================
+ no  | -   | -   | -   | -     | -        | -        || -   | not_applicable
+ yes | -   | -   | -   | -     | yes      | -        || -   | error
+ yes | no  | no  | no  | -     | no       | -        || [1] | pass
+ yes | no  | no  | yes | yes   | no       | no       || [1] | fixed
+ yes | no  | no  | yes | no    | no       | no       || [1] | fixed
+ yes | no  | yes | no  | -     | no       | no       || [1] | fixed
+ yes | no  | yes | yes | yes   | no       | no       || [1] | fixed
+ yes | no  | yes | yes | no    | no       | no       || [1] | fixed
+
+ yes | yes | no  | no  | -     | no       | no       || [2] | needs_inspection
+ yes | yes | no  | yes | yes   | no       | no       || [2] | needs_inspection
+ yes | yes | no  | yes | no    | no       | no       || [2] | needs_inspection
+ yes | yes | yes | no  | -     | no       | no       || [2] | needs_inspection
+ yes | yes | yes | yes | yes   | no       | no       || [2] | needs_inspection
+ yes | yes | yes | yes | no    | no       | no       || [2] | needs_inspection
+
+ yes | no  | no  | yes | yes   | no       | yes      || [2] | needs_action
+ yes | no  | no  | yes | no    | no       | yes      || [2] | needs_action
+ yes | no  | yes | no  | -     | no       | yes      || [2] | needs_action
+ yes | no  | yes | yes | yes   | no       | yes      || [2] | needs_action
+ yes | no  | yes | yes | no    | no       | yes      || [2] | needs_action
+ yes | yes | no  | no  | -     | no       | yes      || [2] | needs_action
+ yes | yes | no  | yes | yes   | no       | yes      || [2] | needs_action
+ yes | yes | no  | yes | no    | no       | yes      || [2] | needs_action
+ yes | yes | yes | no  | -     | no       | yes      || [2] | needs_action
+ yes | yes | yes | yes | yes   | no       | yes      || [2] | needs_action
+ yes | yes | yes | yes | no    | no       | yes      || [2] | needs_action
+
+legend:
+  INST:     openssh-server is installed
+  RA1:      RequiredAuthentications1 detected
+  RA2:      RequiredAuthentications2 detected
+  AKC:      AuthorizedKeysCommand detected
+  AKCRU:    AuthorizedKeysCommandRunAs detected
+  BAK_FAIL: back up failed
+  FIX_FAIL: fix failed
+  BAK:      store (modified) [0] into [1] or [2]
+
+
+[0] /etc/ssh/sshd_config
+[1] /root/preupgrade/cleanconf/etc/ssh/sshd_config
+[2] /root/preupgrade/dirtyconf/etc/ssh/sshd_config
+[3] /etc/ssh/sshd_config.preupg_bp

--- a/RHEL6_7/services/openssh/sysconfig/module_spec
+++ b/RHEL6_7/services/openssh/sysconfig/module_spec
@@ -1,0 +1,69 @@
+==============================================================================
+The module specification:
+==============================================================================
+
+Root cause
+----------
+On RHEL 7 the sshd config file [0] is no longer a shell script as it was
+on RHEL 6 - with the introduction of systemd it has become an environment file
+for sshd systemd service which has a KEY=VALUE syntax [2].
+
+
+short story long:
+-----------------
+  The module is applied when openssh-server is installed. In that case,
+  back up [0] to
+
+    - [1] when result is fixed or pass (IOW when user do not need pay
+          atteantion to the config file.
+    - [3] otherwise as action is needed.
+
+  When export command is used inside [0] and we can ensure it is only presence
+  of shell "code", print solution about changes in RHEL 7 and try to remove
+  export command automatically from [1]. When "sed" utility sucesses, log info
+  and set result fixed. In case that sed fails, require manual action from
+  user (high risk + exit_fail).
+
+  In case we cannot ensure that there is not another code or generally, that
+  produced output between original and new system will be different, always
+  require manual action from user (false positives are expected too here). Here
+  is small set of lines, that are evaluated as suspicious (export command has
+  no effect in this case, still will be removed when it is possible as described
+  above):
+    export VAR=NAME # comment - the comment will be evaluated as string on rh7
+    export VAR="Name $variable something"
+    VAR=$(...)
+    export VAR="This is #1 false positive here"
+    export VAR="This is 2nd false positive here;"
+    export VAR="This is (3rd) false positive here"
+    myfunc() { ... }
+  ... and others. The only goal is to be sure the config file produce same
+  configuration/output on the upgraded system.
+
+long story short:
+-----------------
+
+INST | EXP | CODE || BAK   | FIX | RESULT
+==================||========================
+ no  | -   | -    || -     | -   | not_applicable
+ yes | no  | no   || clean | -   | pass
+ yes | yes | no   || dirty | no  | needs_action (untestable probably)
+ yes | yes | no   || clean | yes | fixed
+ yes | no  | yes  || dirty | -   | needs_action
+ yes | yes | yes  || dirty | no  | needs_action (untestable probably)
+ yes | yes | yes  || dirty | yes | needs_action
+
+legend:
+  INST: openssh-server is installed
+  EXP:  The config file [0] uses export command to set and export environment
+        variables for "relative" utilities
+  BAK:  back up [0] to [1] (clean) or [3] (dirty)
+  FIX:  the "export" command has been removed from [1] (sed returns 0)
+        -- correction: export comman in case a line has the format "export VAR=VAL"
+  CODE: suspicious line has been found (includes possible false positives)
+
+
+[0] /etc/sysconfig/sshd
+[1] /root/preupgrade/cleanconf/etc/sysconfig/sshd
+[2] https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=
+[3] /root/preupgrade/dirtyconf/etc/sysconfig/sshd

--- a/RHEL6_7/services/tomcat/module_spec
+++ b/RHEL6_7/services/tomcat/module_spec
@@ -1,0 +1,79 @@
+==============================================================================
+Whole description of the module:
+==============================================================================
+The module reads configuration files of tomcat and webapps:
+  /etc/tomcat6/server.xml
+  /etc/tomcat6/web.xml
+  /etc/tomcat6/context.xml
+  /etc/tomcat6/tomcat-users.xml
+  /usr/share/tomcat6/webapps/*/WEB-INF/web.xml
+  /usr/share/tomcat6/webapps/*/WEB-INF/context.xml
+
+and check them for incompatibilities mentioned in:
+  https://tomcat.apache.org/migration-7.html#Java_6_required
+
+See solutuionTexts in check.py script, for better understanding. However
+briefly (post below means post-upgrade script something does):
+
+- check & modifications of XML files
+  - when "manager" or  "admin" roles exist (tag rolename in role)
+     - solution text + medium risk + exit failed
+     - post: modify
+         admin -> admin-gui
+         manager -> manager-gui
+       result is not fixed because behaviour can be different
+  - when attrib "randomClass" in "Manager" is used
+     - solution + log info + exit fixed
+     - post: modify
+         randomClass -> secureRandomClass
+  - when attrib "emptySessionPath" in "Connector" is used
+     - log medium risk + exit failed
+     -post:  remove attrib from a tag
+  - when attrib "disableURLRewriting" in "Context" is used:
+     - solution + medium risk + exit fail
+     - post: remove an attrib from a tag
+  - when "param-name" of a "servlet" contains "genStrAsCharArray":
+     - solution + log info + exit fixed
+     - post: modify
+         genStrAsCharArray -> genStringAsCharArray
+  - when "Host" or "Context" contain a "copyXML" attrib:
+     - solution + medium tisk + exit failed
+
+  - when "allow", "deny", "internalProxies" or "trustedProxies"
+    are set as attrib of Valve or set inside servlet (see
+    "init-param" in /etc/tomcat6/web.xml):
+    - solution + log high risk + exit failed
+      (each of them can be logged max. once per file)
+
+  - when attrib "filter" is used in "Valve":
+    - solution + log high risk + exit failed
+      (logged once per file)
+
+  - when attribs "restrictedUserAgents" or "noCompressionUserAgents"
+    are used in "Connector":
+    - solution + log high risk + exit failed
+
+- check script in addition:
+  - copy post-upgrade script "post-tomcat.py" into
+  "<postupgrade dir>/services/tomcat/" with all relevant files to run the
+  postcript correctly and set the file executable
+    - in the same directory, create file "packages" that contains tuples
+      <native-installed-tomcat6-pkg>|<new-tomcat-pkg>
+  - store diff between current server.xml file and default server.xml file
+    into the default_diff.diff file inside current working directory
+    (probably "/root/preupgrade/RHEL6_7/services/tomcat/")
+    NOTE: maybe will be printed to output or stored into different directory
+  - when "tomcat" package is installed (tomcat != tomcat6) - probably from EPEL
+    or 3rd party:
+     - solution + log high risk + copy "remove-tomcat-pre-upgrade.sh" into:
+        "/root/preupgrade/preupgrade-script/"
+       - the script blocks inplace-upgrade during pre-upgrade phase of rhelup
+         when tomcat package is installed
+
+- post upgrade script in addition:
+   - install new rpms according to info in "packages" file
+   - move original tomcat6 configs to the new path
+   - move original webapps to the new path
+     (/usr/share/tomcat/webapps directory is backed up (moved) with suffix
+     "-preupg-backup" prior the move of tomcat6 webapps)
+

--- a/RHEL6_7/system/BinariesRebuild/module_spec
+++ b/RHEL6_7/system/BinariesRebuild/module_spec
@@ -1,0 +1,19 @@
+Description for testing:
+Find all executable binaries and scripts which are not tracked by any rpm and:
+a) when it is binary, add it to file /root/preupgrade/kickstart/binaries
+  - when depends only on safe libraries (below), add sufix message that can
+    be used on new system without rebuild
+b) when it is not binary, add it to file /root/preupgrade/kickstart/scripts
+
+When some untracked binaries or scripts are found, print relevant
+log_slight_risk and exit with result fail. Otherwise result pass.
+
+Safe libraries are libraries which are available on new system. These are
+inside static lists. To get list of all relevant files, use:
+# cd /root/preupgrade/RHEL6_7/common
+# ls default*_so*-kept default*_so*-moved_* default*_so*obsoleted
+
+When common dir [0] or file [1] don't exist, log_error and exit with error.
+
+[0] /root/preupgrade/RHEL6_7/common
+[1] /var/cache/preupgrade/common/executable.log

--- a/RHEL6_7/system/FHS/UsrPartition/module_spec
+++ b/RHEL6_7/system/FHS/UsrPartition/module_spec
@@ -1,0 +1,6 @@
+PASS
+ - the /usr is part of the root partition
+
+FAILED
+ - the /usr is located on a separate partition
+     -> solution + log extreme risk

--- a/RHEL6_7/system/SonameBump/module_spec
+++ b/RHEL6_7/system/SonameBump/module_spec
@@ -1,0 +1,37 @@
+========================
+Description for testing:
+When find some bumped library (below) in RH signed package:
+a) when the package is required by some 3rd party packages
+ - join this into to output message,
+ - same info available inside [4]
+ - and log risk
+   -- MEDIUM - when used only mode migrate (--mode migrate)
+   -- HIGH - otherwise
+
+b) when library is available inside different package(s) on new system, add
+   this info to output message - in this case, this info will be printed even
+   in the case, that library is available inside 2+ packages and one of them
+   is same like old package (may it's little more chatty)
+
+c) when tha package is not required by any 3rd party package, print output
+   message to [5] too
+
+d) at least one is found - log medium risk that some bumped libs were found
+   and exit result FAILED
+
+Exit results:
+ - PASS - not found any bumped library (irrelevant now probably)
+ - FAIL - found at least one bumped library
+ - ERROR - [2] or [3] don't exist (+ log error will be printed)
+
+Bumped libraries
+  - old library is not available anymore, but there is library with higher
+    version. These are inside static lists. To get list of all relevant files,
+    use:
+# cd /root/preupgrade/RHEL6_7/common
+# ls default*_soversioned*bumped*
+
+[2] /root/preupgrade/RHEL6_7/common
+[3] /var/cache/preupgrade/common/rpm_rhsigned.log
+[4] /root/preupgrade/kickstart/SonameBumpedLibs-required
+[5] /root/preupgrade/kickstart/SonameBumpedLibs-optional

--- a/RHEL6_7/system/SonameKept/module_spec
+++ b/RHEL6_7/system/SonameKept/module_spec
@@ -1,0 +1,20 @@
+========================
+Description for testing:
+Find all kept libraries from RH signed packages and print this to [1]. Then
+find libraries, which are available on new system too, but inside different
+package(s) or different repository and print to [1] too. Exit INFORMATIONAL.
+
+When [2] or [3] don't exist, log error and exit error.
+
+Both groups are separated in the file [1] by "comment".
+
+
+Safe libraries are available available on old and new system. These are inside
+static lists. To get list of all relevant files, use:
+# cd /root/preupgrade/RHEL6_7/common
+# ls default*_soversioned-kept default*_so-kept #kept libraries
+# lsdefault*_so*-moved_* default*_so*obsoleted  # moved between repos/pkgs
+
+[1] /root/preupgrade/kickstart/NoSonameBumpLibs
+[2] /root/preupgrade/RHEL6_7/common
+[3] /var/cache/preupgrade/common/rpm_rhsigned.log

--- a/RHEL6_7/system/SonameRemoval/module_spec
+++ b/RHEL6_7/system/SonameRemoval/module_spec
@@ -1,0 +1,29 @@
+===========================
+Description for testing of content:
+Print information about found removed libraries (below). When some relevant library is found (only from packages signed by RH):
+a) when some 3rd party package requires package where is the library, add this
+  info to printed messages, e.g. "(required by NonRH signed package(s):.*)"
+  and set high risk,
+  - message inside [0] too
+b) otherwise just print info to output and [1]
+c) on the end log medium risk that some of these libraries are found and may break some 3rd party applications
+
+Removed libraries are not available on new system and are not bumped. To get list of all relevant files, use:
+# cd /root/preupgrade/RHEL6_7/common
+# ls default*_so*-removed
+
+
+exits codes
+a) PASS - not found anything
+c) FAILED
+  - when 3rd party package requires package where library was found
+    - log MEDIUM risk when --mode migrate is choosed only
+    - log HIGH risk otherwise
+d) ERROR - missing:
+  /var/cache/preupgrade/common/rpm_rhsigned.log
+ /root/preupgrade/RHEL6_7
+
+
+[0] /root/preupgrade/kickstart/RemovedLibs-required
+[1] /root/preupgrade/kickstart/RemovedLibs-optional
+

--- a/RHEL6_7/system/java/module_spec
+++ b/RHEL6_7/system/java/module_spec
@@ -1,0 +1,58 @@
+RESULT           | COND
+=================+====================================
+FIXED            | java-1.7.0-openjdk | java-1.8.0-openjdk
+NEED_INSPECTION  | java-1.5.0-gcj | libgcj
+NEEDS_ACTION     | java-1.6.0-openjdk
+NOT_APPLICABLE   | Nor Java OpenJDK neither GCJ are installed
+
+* When java-1.5.0-gcj or libgcj are installed, log medium risk + solution
+  text. If these are required by some non-native packages, a list of them
+  is part of log.
+* When java-1.6.0-openjdk is installed, log high risk + solution text
+* When OpenJDK 6+ are installed, backup these files from each relevant JVM
+  directory into dirtyconf:
+    jre/lib/calendars.properties
+    jre/lib/content-types.properties
+    jre/lib/flavormap.properties
+    jre/lib/logging.properties
+    jre/lib/net.properties
+    jre/lib/psfontj2d.properties
+    jre/lib/sound.properties
+    jre/lib/deployment.properties
+    jre/lib/deployment.config
+    jre/lib/security/US_export_policy.jar
+    jre/lib/security/java.policy
+    jre/lib/security/java.security
+    jre/lib/security/local_policy.jar
+    jre/lib/security/nss.cfg
+    jre/lib/ext
+  (the last one is directory, backed up are all files inside)
+  JVM dir is e.g. '/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.121.x86_64'.
+  Simply, name is NVA of rpm.
+
+* When OpenJDK 7 and/or 8 are installed, append info about JVM dir
+  inside [1], in format:
+    rpmname|JVMdir
+  (e.g.: java-1.7.0-openjdk|/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.121.x86_64)
+  and copy post-upgrade script into [2].
+  - post-upgrade script (only for OpenJDK 7+):
+    - when expected Java OpenJDK is not installed (according to [1]), install
+      it (and java-1.?.0-openjdk-headless, which owns the JVM directory on
+      the RHEL 7). Log error when installation fail and skip to another java
+      in list)
+    - recover backed up files (JVM dir on rhel 7 has name == NVRA of the
+      java-1.?.0-openjdk rpm). When backed up file is identical to one stored
+      on the system, skip it. Otherwise replaced file back up with '.preupg'
+      suffix
+    - remove OpenJDK java that was not installed on previous system if it is
+      possible and log info. Otherwise log warning.
+
+* When more then 1 OpenJDK are installed, log sligh risk and save currently
+  used alternatives for java in [0] (currently any action is not done with
+  this info, it seems that it will be relevant for migration only in future.)
+
+
+[0] /root/preupgrade/postupgrade.d/system/java/current_alternatives
+[1] /root/preupgrade/postupgrade.d/system/java/jvmdir_list
+[2] /root/preupgrade/postupgrade.d/system/java/java-post.sh
+

--- a/RHEL6_7/system/yaboot/module_spec
+++ b/RHEL6_7/system/yaboot/module_spec
@@ -1,0 +1,33 @@
+=======================================
+Specification
+=======================================
+- exit as not applicable unless ppc64 architecture is used
+
+- Log error message and exit with ERROR when:
+  - cannot detect architecture (very improbable, do not need test)
+
+NEEDS_ACTION
+(if... then...)
+- the yaboot RPM is not installed (unsupported solution for ppc64
+  architecture) or it is not signed by Red Hat
+    - inform user that yaboot signed by RH has to be installed and
+      used for booting of the system + log high risk
+- the /etc/default/grub doesn't exists yet:
+    - generate [1] for the grub2 (should be correct at least for basic/default
+      installation and partitioning)
+    - inform user that content of the file has to be checked and then moved
+      into the /etc/default/grub
+    - high risk
+- the /etc/default/grub exists:
+    - back up the file into [1] (+ log info)
+    - inform user that validity of the file should be check
+    - high risk
+
+In addition the pre-upgrade script [0] must exists, which will be processed
+by r-u-t and which exits with 1 when:
+  - yaboot rpm is not installed or it is not signed by Red Hat
+    (note: ignores activation of the devel_mode)
+  - the /etc/default/grub doesn't exist or it is not regular file
+
+[0] /root/preupgrade/preupgrade-scripts/yaboot/yaboot_check
+[1] /root/preupgrade/dirtyconf/etc/default/grub

--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -91,6 +91,7 @@ rm -rf $RPM_BUILD_ROOT/%{_datadir}/preupgrade/common
 find $RPM_BUILD_ROOT%{_datadir}/preupgrade/RHEL6_7 -regex ".*/\(module\|group\)\.ini$" -regextype grep -delete
 find $RPM_BUILD_ROOT%{_datadir}/preupgrade/ -name "READY" -delete
 find $RPM_BUILD_ROOT -name '.gitignore' -delete
+find $RPM_BUILD_ROOT -name 'module_spec' -delete
 
 
 %clean


### PR DESCRIPTION
We have already created specifications of some modules. Some of them accepted favourite *case studies* format, some of them are written with exhausting description only, but still they shoul provide full documentation for purposes of testing.

Part of this PR is modification of the SPEC file, that removes *module_spec* files from RPM, so these files will not be installed on system.