### PR TITLE
Include basic patches for system/requirement

### DIFF
--- a/RHEL6_7/system/requirements/check
+++ b/RHEL6_7/system/requirements/check
@@ -103,7 +103,15 @@ get_free_size() {
 }
 
 get_memory_size() {
-  MEMSIZE=$(dmidecode -t 17 | awk '( /Size/ && $2 ~ /^[0-9]+$/ ) { x+=$2 } END{ print x}')
+  # MEMSIZE is in MB
+  MEMSIZE=$(dmidecode -t 17 \
+    | awk '( /Size/ && $2 ~ /^[0-9]+.B$/ ) {match($2, /^([0-9]+)(.B)$/, arr); $2=arr[1]; $3=arr[2]}
+           ( /Size/ && $3 ~ /^[kK]B$/ ) { unit=1.0/1024 }
+           ( /Size/ && $3 ~ /^MB$/ ) { unit=1 }
+           ( /Size/ && $3 ~ /^GB$/ ) { unit=2**10 }
+           ( /Size/ && $3 ~ /^TB$/ ) { unit=2**20 }
+           ( /Size/ && $2 ~ /^[0-9]+$/ ) { x+=int($2*unit) }
+           END{ print x}')
   [ -n "$MEMSIZE" ] && return 0
 
   #maybe virtual machine, so we can get only aroximation of real RAM size

--- a/RHEL6_7/system/requirements/check
+++ b/RHEL6_7/system/requirements/check
@@ -79,7 +79,7 @@ print_needed_free_capacity() {
 
   # I keep check of boot - probably pointless too, however
   # wrong
-  dir_sizes+=( [/usr]=0 [/var]=0 [/boot]=20480 )
+  dir_sizes+=( [/usr]=0 [/var]=0 [/boot]=$(( 110 * kB )) )
   ssizes=( $(get_sizes) )
   # 400 is hard magic contant for basic installation and dependencies
   # there is different too due to 4kB rounding on default ext4 fs
@@ -185,6 +185,8 @@ usr_ncap=$(print_needed_free_capacity "/usr")
 usr_acap=$(get_free_size "/usr")
 var_ncap=$(print_needed_free_capacity "/var")
 var_acap=$(get_free_size "/var")
+boot_ncap=$(print_needed_free_capacity "/boot" )
+boot_acap=$(get_free_size "/boot")
 
 usr_reserve=$[ $usr_ncap+($usr_ncap/100*15) ]
 var_reserve=$[ $var_ncap+($var_ncap/100*15) ]
@@ -229,6 +231,14 @@ it instead of network." >> solution.txt
   result=$RESULT_FAIL
 fi
 
+if [ $boot_acap -le $boot_ncap ]; then
+  log_high_risk "Not enough free space on the /boot. Release more space for upgrade."
+  echo -e "\nFree space in the /boot/ directory is smaller then the estimated free space required
+for the secure upgrade. You need to release more space on the partition." >> solution.txt
+  result=$RESULT_FAIL
+fi
+
+
 echo "
 /usr:
 (only for migration process)
@@ -241,6 +251,10 @@ Available free space: $usr_acap kB
 Estimated needed free space: $var_ncap kB
 Estimated safe free space: $var_reserve kB
 Available free space: $var_acap kB
+
+/boot
+Estimated required free space: $boot_ncap kB
+Available free space: $boot_acap kB
 " >> solution.txt
 
 exit $result


### PR DESCRIPTION
Get correct info about size of RAM, that can be provided in various units than kB (MB, TB, ...) by the dmidecode utility. In addition check that boot partition has enough free space for upgrade. Currently set 110 MB as limit to be sure that upgrade will be always safe - from the point of free space on the boot partition.

The module needs to be rewritten still, but these fixes are necessary to have applied. Both are well tested so they don't need to be verified now.