### PR TITLE
 system/perl - local dirs only

### DIFF
--- a/RHEL6_7/system/perl/check
+++ b/RHEL6_7/system/perl/check
@@ -23,6 +23,15 @@ EOM
 
 PERL_DIRS=$(perl -MConfig -e '$,=q{ }; print @Config{installarchlib,installprivlib,installvendorarch,installvendorlib}') \
     || exit_error
+#Limiting the lookup to local directories only
+for dir in ${PERL_DIRS[@]};
+do 
+    fs_type=$(stat -f -L -c %T "$dir")
+    if  echo "$fs_type" | egrep -q 'nfs|nfs4|autofs|cifs|sshfs|fuseblk'; then
+        PERL_DIRS=( "${PERL_DIRS[@]/$dir}")
+        log_info "Directory $dir is not on the local filesystem and it will be skipped in the analysis"
+    fi
+done
 for file in $(find -P $PERL_DIRS -type f -name '*.pm'); do
     RPM=$(rpm -qf "$file")
     if [ $? -ne 0 ]; then

--- a/RHEL6_7/system/perl/check
+++ b/RHEL6_7/system/perl/check
@@ -6,9 +6,28 @@
 #END GENERATED SECTION
 
 FOREIGN_FOUND=0
-function log_file() {
-        printf '%s\n' "$@" >> "$SOLUTION_FILE" || exit_error
-        FOREIGN_FOUND=1
+log_file() {
+    printf '%s\n' "$@" >> "$SOLUTION_FILE" || exit_error
+    FOREIGN_FOUND=1
+}
+is_module_rh() {
+    
+    if [ $# -ne 1 ]; then
+         return 1
+    fi
+    
+    RPM_NAME=$(rpm -qf --qf '%{NAME}\n' "$1")
+    
+    if [ $? -eq 1 ]; then
+        log_slight_risk "The $1 Perl module is not handled by any package."
+        log_file "$1"
+    else
+        is_dist_native $RPM_NAME
+        if [ $? -ne 0 ]; then
+            log_slight_risk "The $1 Perl module was not installed by any package signed by Red Hat."
+            log_file "$1"
+        fi
+    fi
 }
 
 cat > "$SOLUTION_FILE" <<'EOM'
@@ -33,18 +52,7 @@ do
     fi
 done
 for file in $(find -P $PERL_DIRS -type f -name '*.pm'); do
-    RPM=$(rpm -qf "$file")
-    if [ $? -ne 0 ]; then
-        log_slight_risk "The $file perl module is not handled by any package."
-        log_file "$file"
-        continue
-    fi
-    RPM_NAME=$(rpm -q --qf '%{NAME}' "$RPM")
-    is_dist_native "$RPM_NAME"
-    if [ $? -ne 0 ]; then
-        log_slight_risk "The $file perl module was not installed by any package signed by Red Hat."
-        log_file "$file"
-    fi
+    is_module_rh "$file"
 done
 
 test "$FOREIGN_FOUND" = 0 && exit_informational || exit_fail


### PR DESCRIPTION
 - limiting lookup of the perl
   modules to local directories
   only to shorten the execution
   time