### PR TITLE
Rename multiple network devices

### DIFF
--- a/RHEL6_7/system/initscripts/ifcfg/check
+++ b/RHEL6_7/system/initscripts/ifcfg/check
@@ -35,7 +35,7 @@ else:
 def ifcfg_error():
     """https://bugzilla.redhat.com/show_bug.cgi?id=1111174
 1) kernel names (eth0, eth1, ...)
-a) DEVICE + HWADDR specified in ifcfg files = not safe, udev in rhel7 is not able to swap names (onlky exception here are machines with only one network interface, they should be fine) <- this is only thing which is covered by content which I wrote
+a) DEVICE + HWADDR specified in ifcfg files = not safe, udev in rhel7 is not able to swap names (only exception here are machines with only one network interface, they should be fine)
 b) only DEVICE specified in ifcfg files = not safe, udev will probably name the interface differently in rhel7
 c) only HWADRR specified in ifcfg files = uh, device will be set up correctly according to ifcfg file but name could be different
 2) biosdevname names (em1, p3p4, p3p4_1, ...)
@@ -43,8 +43,7 @@ On dell machines you should be fine in all cases, for others biosdevname was not
 3) custom names (my_little_network_card, ...)
 both HWADDR and DEVICE are specified in this case or you have written your own udev rules.
 This is safe in the case that you use truly unique names, they should not match any other naming methods (kernel, biosdevname or udev in rhel7).
-1a is covered ()
-We should refuse to update also in the 1b case.
+1a and 1b are covered ()
 If you are using 1c case you are used to some level of pain, so it would be enough just to write a warning.
 2 is fine.
 I case 3, to be completely correct you could check that user is not using rhel7 udev naming scheme [1] in rhel6, but I would bet that nobody uses that.
@@ -102,8 +101,18 @@ I case 3, to be completely correct you could check that user is not using rhel7 
                 return True
         return False
 
+    def fix_ifnames():
+        script_result = subprocess.Popen("./preupg_network.sh", shell=True)
+        script_result.communicate()
+        exit_code = script_result.returncode
+        if exit_code == 1:
+            log_extreme_risk("The network interface names on the source system are in an inconsistent state, so the upgrade is not possible")
+        elif exit_code == 2:
+            log_extreme_risk("Comment out the MACADDR directive in the ifcfg files and run the Preupgrade Assistant again to enable the upgrade.")
 
     ethx_with_addr_count = 0
+    ethx_without_addr_count = 0
+    ifnames_to_fix = 0
     warning = False
     for script in ls_scripts():
         full_path = ifcfg_path + script
@@ -124,18 +133,23 @@ I case 3, to be completely correct you could check that user is not using rhel7 
                 if addr:
                     ethx_with_addr_count +=1
                 else:
+                    ethx_without_addr_count +=1
                     log_slight_risk(full_path + " is old style ethX name without HWADDR, its name can change after the upgrade.")
                     warning = True
             elif is_udev(name):
                 log_slight_risk(full_path + " variable DEVICE is similar to udev predictable network naming scheme. It might cause conflicts.")
                 warning = True
 
-        if ethx_with_addr_count > 1:
-            log_medium_risk("You use multiple network devices with old style 'ethX' names.")
+        if ethx_with_addr_count > 1 or ethx_without_addr_count > 1:
+            ifnames_to_fix +=1
             warning = True
-        if ethx_with_addr_count == 1:
-            log_slight_risk("You use one network device with an old style 'ethX' name. This will work as long as you only have one, but it will break with multiple such devices.")
+        elif ethx_with_addr_count == 1:
+            log_slight_risk("You use one network device with an old style 'ethX' name.")
             warning = True
+
+    if ifnames_to_fix > 0:
+        fix_ifnames()
+        log_high_risk("You use multiple network devices with old style 'ethX' names.")
     return warning
 
 if __name__ == "__main__":

--- a/RHEL6_7/system/initscripts/ifcfg/check
+++ b/RHEL6_7/system/initscripts/ifcfg/check
@@ -7,25 +7,25 @@ import re
 
 devel_time = False
 if devel_time:
-	def log_debug(x):
-		print x
+    def log_debug(x):
+        print x
 
-	def log_warning(x):
-		print x
+    def log_warning(x):
+        print x
 
-	def log_error(x):
-		print x
+    def log_error(x):
+        print x
 
-	def exit_pass():
-		sys.exit(0)
-	
-	def exit_fail():
-		sys.exit(1)
+    def exit_pass():
+        sys.exit(0)
 
-	def exit_error():
-		sys.exit(-1)
+    def exit_fail():
+        sys.exit(1)
+
+    def exit_error():
+        sys.exit(-1)
 else:
-	from preupg.script_api import *
+    from preupg.script_api import *
 
 #END GENERATED SECTION
 # exit functions are exit_{pass,not_applicable, fixed, fail, etc.}
@@ -33,8 +33,8 @@ else:
 # for logging in-place risk use functions log_{extreme, high, medium, slight}_risk
 
 def ifcfg_error():
-	"""https://bugzilla.redhat.com/show_bug.cgi?id=1111174
-1) kernel names (eth0, eth1, ...) 
+    """https://bugzilla.redhat.com/show_bug.cgi?id=1111174
+1) kernel names (eth0, eth1, ...)
 a) DEVICE + HWADDR specified in ifcfg files = not safe, udev in rhel7 is not able to swap names (onlky exception here are machines with only one network interface, they should be fine) <- this is only thing which is covered by content which I wrote
 b) only DEVICE specified in ifcfg files = not safe, udev will probably name the interface differently in rhel7
 c) only HWADRR specified in ifcfg files = uh, device will be set up correctly according to ifcfg file but name could be different
@@ -45,105 +45,105 @@ both HWADDR and DEVICE are specified in this case or you have written your own u
 This is safe in the case that you use truly unique names, they should not match any other naming methods (kernel, biosdevname or udev in rhel7).
 1a is covered ()
 We should refuse to update also in the 1b case.
-If you are using 1c case you are used to some level of pain, so it would be enough just to write a warning. 
+If you are using 1c case you are used to some level of pain, so it would be enough just to write a warning.
 2 is fine.
 I case 3, to be completely correct you could check that user is not using rhel7 udev naming scheme [1] in rhel6, but I would bet that nobody uses that.
 """
 
 
-	ifcfg_path = "/etc/sysconfig/network-scripts/"
-	ifcfg_prefix = "ifcfg-"
+    ifcfg_path = "/etc/sysconfig/network-scripts/"
+    ifcfg_prefix = "ifcfg-"
 
-	def get_variable(path, variable):
-		err_msg = "Error while reading ifcfg scripts"
-		def err(output):
-			log_error(err_msg)
-			log_error(output.read())
+    def get_variable(path, variable):
+        err_msg = "Error while reading ifcfg scripts"
+        def err(output):
+            log_error(err_msg)
+            log_error(output.read())
 
-		try:
-			output = os.tmpfile();
-			(currentpath, _ ) = os.path.split(os.path.realpath(__file__))
-			return_code = subprocess.Popen([currentpath + "/get_var_by_name.sh", path, variable],
-			bufsize=0,
-			executable=None,
-			stdin=None,
-			stdout=output,
-			stderr=subprocess.STDOUT,
-			preexec_fn=None,
-			close_fds=True,
-			shell=False,
-			cwd=None,
-			env=None,
-			universal_newlines=False,
-			startupinfo=None,
-			creationflags=0).wait()
-		except:
-			output.seek(0)
-			err(output)
-			raise
-		output.seek(0)
-		if return_code < 0:#error
-			log_error(output.read())
-			raise err_msg
-		if return_code == 1:#undefined variable
-			return False
-		return output.read().strip()
+        try:
+            output = os.tmpfile();
+            (currentpath, _ ) = os.path.split(os.path.realpath(__file__))
+            return_code = subprocess.Popen([currentpath + "/get_var_by_name.sh", path, variable],
+            bufsize=0,
+            executable=None,
+            stdin=None,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            preexec_fn=None,
+            close_fds=True,
+            shell=False,
+            cwd=None,
+            env=None,
+            universal_newlines=False,
+            startupinfo=None,
+            creationflags=0).wait()
+        except:
+            output.seek(0)
+            err(output)
+            raise
+        output.seek(0)
+        if return_code < 0:#error
+            log_error(output.read())
+            raise err_msg
+        if return_code == 1:#undefined variable
+            return False
+        return output.read().strip()
 
-	def ls_scripts():
-		for f in [i for i in os.listdir(ifcfg_path) if i.startswith(ifcfg_prefix)]:
-			yield f
-	
-	def is_kernel(name):
-		return re.match("eth[0-9]+", name)
+    def ls_scripts():
+        for f in [i for i in os.listdir(ifcfg_path) if i.startswith(ifcfg_prefix)]:
+            yield f
 
-	def is_udev(name):
-		if name[0:2] in ("en", "sl", "wl", "ww"):
-			if name[2] in ("b", "c", "o", "s", "x", "P", "p"):
-				return True
-		return False
+    def is_kernel(name):
+        return re.match("eth[0-9]+", name)
+
+    def is_udev(name):
+        if name[0:2] in ("en", "sl", "wl", "ww"):
+            if name[2] in ("b", "c", "o", "s", "x", "P", "p"):
+                return True
+        return False
 
 
-	ethx_with_addr_count = 0
-	warning = False
-	for script in ls_scripts():
-		full_path = ifcfg_path + script
-		addr = get_variable(full_path, "HWADDR")
-		name = get_variable(full_path, "NAME" if devel_time else "DEVICE")
-		log_debug("checking " + script + ", name: " + str(name) + " hwaddr: " + str(addr))
-		short_name = script[len(ifcfg_prefix):]
-		if short_name == "lo": #loopback
-			continue
-		if not name:
-			warning = True
-			if not addr:
-				log_slight_risk(full_path + " does not have DEVICE nor HWADDR set, what kind of device is it?")
-			else:
-				log_slight_risk(full_path + " does not have DEVICE set, its name can change after the upgrade.")
-		else:
-			if is_kernel(name):
-				if addr:
-					ethx_with_addr_count +=1
-				else:
-					log_slight_risk(full_path + " is old style ethX name without HWADDR, its name can change after the upgrade.")
-					warning = True
-			elif is_udev(name):
-				log_slight_risk(full_path + " variable DEVICE is similar to udev predictable network naming scheme. It might cause conflicts.")
-				warning = True
+    ethx_with_addr_count = 0
+    warning = False
+    for script in ls_scripts():
+        full_path = ifcfg_path + script
+        addr = get_variable(full_path, "HWADDR")
+        name = get_variable(full_path, "NAME" if devel_time else "DEVICE")
+        log_debug("checking " + script + ", name: " + str(name) + " hwaddr: " + str(addr))
+        short_name = script[len(ifcfg_prefix):]
+        if short_name == "lo": #loopback
+            continue
+        if not name:
+            warning = True
+            if not addr:
+                log_slight_risk(full_path + " does not have DEVICE nor HWADDR set, what kind of device is it?")
+            else:
+                log_slight_risk(full_path + " does not have DEVICE set, its name can change after the upgrade.")
+        else:
+            if is_kernel(name):
+                if addr:
+                    ethx_with_addr_count +=1
+                else:
+                    log_slight_risk(full_path + " is old style ethX name without HWADDR, its name can change after the upgrade.")
+                    warning = True
+            elif is_udev(name):
+                log_slight_risk(full_path + " variable DEVICE is similar to udev predictable network naming scheme. It might cause conflicts.")
+                warning = True
 
-		if ethx_with_addr_count > 1:
-			log_medium_risk("You use multiple network devices with old style 'ethX' names.")
-			warning = True
-		if ethx_with_addr_count == 1:
-			log_slight_risk("You use one network device with an old style 'ethX' name. This will work as long as you only have one, but it will break with multiple such devices.")
-			warning = True
-	return warning
+        if ethx_with_addr_count > 1:
+            log_medium_risk("You use multiple network devices with old style 'ethX' names.")
+            warning = True
+        if ethx_with_addr_count == 1:
+            log_slight_risk("You use one network device with an old style 'ethX' name. This will work as long as you only have one, but it will break with multiple such devices.")
+            warning = True
+    return warning
 
 if __name__ == "__main__":
-	if os.geteuid() != 0 and not devel_time:
-		sys.stdout.write("Need to be root.\n")
-		log_slight_risk("The script needs to be run under root.")
-		exit_error()
-	if ifcfg_error():
-		exit_fail()
-	else:
-		exit_pass()
+    if os.geteuid() != 0 and not devel_time:
+        sys.stdout.write("Need to be root.\n")
+        log_slight_risk("The script needs to be run under root.")
+        exit_error()
+    if ifcfg_error():
+        exit_fail()
+    else:
+        exit_pass()

--- a/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
+++ b/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+. /usr/share/preupgrade/common.sh
+
+orig_name_base="eth"
+new_name_base="net"
+conf_dir='/etc/sysconfig/network-scripts'
+temp_conf_dir='/root/preupgrade/dirtyconf/etc/sysconfig/network-configuration_fixed/'
+preupg_script='/root/preupgrade/preupgrade-scripts/rename_network.sh'
+udev_command='/sbin/udevadm info -a  -p'
+dev_path='/sys/class/net'
+index=0
+
+declare -a netX_indices
+declare -a ethX_ifaces
+
+for net_index in $(ip a | awk -F': ' '/^[[:digit:]]: net[[:digit:]]+/ {print $2  }' | sed -e "s/net//g"| sort )
+do
+    netX_indices+=( "$net_index" )
+done
+
+for eth_iface in $(ip a | awk -F': ' '/^[[:digit:]]: eth[[:digit:]]+/ {print $2  }')
+do
+    ethX_ifaces+=( "$eth_iface" )
+done
+
+if [ ${#netX_indices[@]} -ne 0 ] && [ ${#ethX_ifaces[@]} -gt 1 ];then
+   log_info "There are pre-existing netX interfaces on the system as well as multiple ethX interfaces. The index of renamed ethX interfaces will be changed in order to prevent the naming conflicts."
+fi
+
+cat /dev/null > udev_temp 
+cat /dev/null > "$preupg_script"
+
+echo '#!/bin/bash' >> "$preupg_script"
+echo 'service network stop'  >> "$preupg_script"
+
+if ls "$dev_path" | grep -q "rename[0-9]+$";then
+    exit 1
+fi
+
+if grep -q "^MACADDR=" "$conf_dir"/ifcfg-*;then
+    exit 2
+fi
+
+if ! [ -e "$temp_conf_dir" ];then
+    mkdir -p "$temp_conf_dir"
+fi
+
+for orig_full_name in ${ethX_ifaces[@]}
+do
+    orig_conf_file="${conf_dir}/ifcfg-${orig_full_name}"
+    mac=$(/sbin/ethtool -P $orig_full_name | awk '{ print $3}')
+    mac_rule=$(echo "ATTR{address}==\"$mac\"")
+    dev_type_rule=$($udev_command "${dev_path}/${orig_full_name}" | egrep "ATTR\{type\}")
+    index=$(echo $orig_full_name |sed -e "s/^$orig_name_base//g")
+
+    for net_index in ${netX_indices[@]}
+    do
+        while [ $index -eq $net_index ]
+        do
+            index=$(expr $index + 1)
+        done
+    done
+    netX_indices=(${netX_indices[@]} $index )
+    new_full_name="${new_name_base}$index"
+    log_info "On the target system, the $orig_full_name interface will become $new_full_name."
+
+    if [ -f "$orig_conf_file" ];then
+        if [ -n "$new_full_name" ];then
+           new_conf_file="${temp_conf_dir}/ifcfg-${new_full_name}"
+           cp -p "$orig_conf_file" "$new_conf_file"
+           sed -i "s/^HWADDR=.*/HWADDR=$mac/g" "$new_conf_file"
+           sed -r -i "s/^NAME=.*|^DEVICE=.*/DEVICE=$new_full_name/g" "$new_conf_file"
+           echo "ip link set $orig_full_name name $new_full_name" >> "$preupg_script"
+           echo "cp -p $new_conf_file $conf_dir" >> "$preupg_script"
+           echo "rm -f $orig_conf_file" >> "$preupg_script"
+        fi
+    fi
+
+    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", $mac_rule, $dev_type_rule, KERNEL==\"${orig_name_base}*\", NAME=\"$new_full_name\"\n" >> udev_temp
+
+done
+
+
+mv udev_temp "$temp_conf_dir"
+echo "cp -p $temp_conf_dir/udev_temp /etc/udev/rules.d/70-persistent-net.rules" >> "$preupg_script"
+echo 'service network start'  >> "$preupg_script"
+chmod u+x "$preupg_script"
+
+
+echo "The interfaces with \"$orig_name_base\" prefix will be renamed to use \"$new_name_base\" prefix by $preupg_script script executed by redhat-upgrade-tool before the upgrade.
+      This process includes the restart of the network" >> solution.txt
+


### PR DESCRIPTION
This pull request addresses the problem of the network not coming up after the in-place upgrade of a RHEL 6 machine **with multiple network devices** to RHEL 7.

The module _RHEL6_7/system/initscripts/ifcfg/_ (_xccdf_preupg_rule_system_initscripts_ifcfg_check_) has been updated so that when multiple ethX network devices are present, it generates alternative ifcfg files and udev rules to rename the network devices.

Renaming the network interfaces is automated by a preupgrade script generated by the Preupgrade Assistant module (`/root/preupgrade/preupgrade-scripts/rename_network.sh`) - this script is executed automatically by the redhat-upgrade-tool during the upgrade process, before the user is instructed by the tool to reboot. The user is still expected to review the report and the generated files.

Notes:
- the interfaces are renamed from "eth[0-9]+" to "net[0-9]+", if there are no pre-existing interfaces with "net"  prefix 
- pre-existing interfaces with "net" prefix are taken into account and conflicts are prevented by raising index number of the newly renamed interfaces
- network can be normally restarted with ifup/ifdown scripts after the upgrade
- renaming works correctly with bonded ethX interfaces - the information about which bond device the ethX network interface participates in is configured in the ifcfg-ethX and it is transferred without change to the ifcfg-netX
- occurence of MACADDR directive in ifcfg-ethX would break the network upgrade process, so it inhibits the upgrade