### PR TITLE
Unset the release

### DIFF
--- a/RHEL6_7/system/subscription-manager/module.ini
+++ b/RHEL6_7/system/subscription-manager/module.ini
@@ -1,5 +1,5 @@
 [preupgrade]
 content_title: Red Hat Subscription Manager
-content_description: The module adds a new option 'full_refresh_on_yum' to the configuration file, if it is not there already.
+content_description: The module adds a new option 'full_refresh_on_yum' to the configuration file, if it is not there already. Also, unsets the release with subscription-manager.
 author: Jakub Dornak <jdornak@redhat.com>
 applies_to: subscription-manager

--- a/RHEL6_7/system/subscription-manager/postupgrade.sh
+++ b/RHEL6_7/system/subscription-manager/postupgrade.sh
@@ -13,3 +13,5 @@ if ! egrep -q '^full_refresh_on_yum ?=' /etc/rhsm/rhsm.conf; then
     fi
 fi
 
+# unset the release, so after the upgrade the subscription-manager downloads updates for the latest minor RHEL 7 version
+subscription-manager release --unset


### PR DESCRIPTION
This way, after the upgrade the subscription-manager always downloads updates for the latest minor RHEL 7 version.

This action covers the corner case of the RHEL 6 system having a release set (e.g. `subscription-manager release --set=6.9`). That would cause the upgrade to fail as yum would be trying to access RHEL 6.9 release under RHEL 7 repos.