### PR TITLE
   drivers/ObsoletedNetworkDrivers

### DIFF
--- a/RHEL6_7/drivers/ObsoletedNetworkDrivers/check
+++ b/RHEL6_7/drivers/ObsoletedNetworkDrivers/check
@@ -10,13 +10,13 @@ declare -A drivers
 declare -A modules
 
 for i in /sys/bus/*/devices/*/driver; do
-	_driver=$(readlink -f $i | cut -d '/' -f 6)
+	_driver=$(readlink -f "$i" | cut -d '/' -f 6)
 	_bus=$(echo $i | cut -d '/' -f 4)
 	_id=$(echo $i | cut -d '/' -f 6)
 	drivers[$_driver]="${drivers[$_driver]} $_bus|$_id"
 done
 for i in /sys/bus/*/devices/*/driver/module; do
-	_module=$(readlink -f $i | cut -d '/' -f 4)
+	_module=$(readlink -f "$i" | cut -d '/' -f 4)
 	_bus=$(echo $i | cut -d '/' -f 4)
 	_id=$(echo $i | cut -d '/' -f 6)
 	modules[$_module]="${modules[$_module]} $_bus|$_id"


### PR DESCRIPTION
Whitespace appearing in the name of one of the drivers on the system caused the readlink command to return an error with coreutils-8.4-37 installed on RHEL-6.7. The fix is that the name is enclosed in double quotes.
Resolves https://github.com/upgrades-migrations/preupgrade-assistant-modules/issues/42.