### PR TITLE
RemovedPackages: added noauto postupgrade script

### DIFF
--- a/RHEL6_7/packages/RemovedPackages/check
+++ b/RHEL6_7/packages/RemovedPackages/check
@@ -39,13 +39,13 @@ cp "$POSTUPGRADE_DIR/$(basename $VALUE_RPM_RHSIGNED)" "$NOAUTO_POST_DIR"
 found=0
 rm -f solution.txt
 echo \
-"Some packages were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break
+"Some packages were removed between Red Hat Enterprise Linux (RHEL) 6 and RHEL 7. This might break
 the upgrade for some of your packages. We are not aware of any compatible
 replacement for these packages.
 
 Use the '--cleanup-post' option of redhat-upgrade-tool to remove them
 automatically during upgrade. You can also run the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script
-manually after the upgrade to remove only those Red Hat-signed (RHEL) 6 packages
+manually after the upgrade to remove only those RHEL 6 packages signed by Red Hat
 that have broken dependencies. The script also fixes possible broken
 dependencies of the newly installed packages.
 
@@ -56,7 +56,7 @@ while read pkg
 do
   #skip non-rh and unavailable packages
   is_pkg_installed "$pkg" && is_dist_native $pkg || continue
-  j=" (required by NonRH signed package(s):"
+  j=" (required by packages not signed by Red Hat:"
   for k in $(rpm -q --whatrequires $pkg | grep -v "^no package requires" | \
    rev | cut -d'-' -f3- | rev)
   do
@@ -64,8 +64,8 @@ do
     is_dist_native $k ||  j="$j$k "
   done
   j="${j% })"
-  [ "$j" == " (required by NonRH signed package(s):)" ] && j=""
-  [ -n "$j" ] && log_high_risk "The $pkg $j package was removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7."
+  [ "$j" == " (required by packages not signed by Red Hat:)" ] && j=""
+  [ -n "$j" ] && log_high_risk "The $pkg $j package was removed between RHEL 6 and RHEL 7."
   echo "$pkg$j" >>solution.txt
   found=1
 done < "$RemovedPkgs"
@@ -76,21 +76,21 @@ grep -v required solution.txt | grep -v " " | grep -v "^$" >> "$KICKSTART_DIR/Re
 grep required "$KICKSTART_DIR/RemovedPkg-required" >/dev/null || rm "$KICKSTART_DIR/RemovedPkg-required"
 grep [a-zA-Z] "$KICKSTART_DIR/RemovedPkg-optional" >/dev/null || rm "$KICKSTART_DIR/RemovedPkg-optional"
 [ -f "$KICKSTART_DIR/RemovedPkg-required" ] && \
-  echo " * RemovedPkg-required - This file contains all Red Hat Enterprise Linux 6 packages that were removed in Red Hat Enterprise Linux 7. There is no known compatible-enough alternative for them. As some of your packages depend on them, check the changes carefully." >>"$KICKSTART_README"
+  echo " * RemovedPkg-required - This file contains all RHEL 6 packages that were removed in RHEL 7. There is no known compatible alternative for them. As some of your packages depend on them, check the changes carefully." >>"$KICKSTART_README"
 [ -f "$KICKSTART_DIR/RemovedPkg-optional" ] && \
   echo " * RemovedPkg-optional - Similar to the RemovedPkg-required file, but in this case, no package not signed by Red Hat requires this. It is more of an informational thing for you, so that you can deal with the unavailability of these packages." >>"$KICKSTART_DIR/README"
 
 echo \
 "
-If a package not signed by Red Hat requires these packages, you may need to ask your
-vendor to provide an alternative solution, or you may get the missing package from
-other sources than Red Hat Enterprise Linux.
+If a package not signed by Red Hat requires these packages, ask your
+vendor to provide an alternative solution, or get the missing package from
+other sources than RHEL.
 
 " >>solution.txt
-[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux (RHEL) 7, there are still some RHEL 6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script manually after the upgrade to remove only those Red Hat-signed RHEL 6 packages that have broken dependencies."
+[ $found -eq 1 ] && log_high_risk "After upgrading to RHEL 7, there are still some RHEL 6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script manually after the upgrade to remove only those Red Hat-signed RHEL 6 packages that have broken dependencies."
 
 [ $found -eq 1 ] && log_medium_risk "\
-Some packages installed on the system were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break the functionality of the packages that depend on the removed packages." && exit $RESULT_FAIL
+Some packages installed on the system were removed between RHEL 6 and RHEL 7. This might break the functionality of the packages that depend on the removed packages." && exit $RESULT_FAIL
 
 rm -f solution.txt && touch solution.txt
 

--- a/RHEL6_7/packages/RemovedPackages/check
+++ b/RHEL6_7/packages/RemovedPackages/check
@@ -44,10 +44,10 @@ the upgrade for some of your packages. We are not aware of any compatible
 replacement for these packages.
 
 Use the '--cleanup-post' option of redhat-upgrade-tool to remove them
-automatically during upgrade. You can also run manually the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script
-after the upgrade to remove only the original native packages with broken
-dependencies. The script also fixes possible broken dependencies of the newly
-installed packages.
+automatically during upgrade. You can also run the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script
+manually after the upgrade to remove only those Red Hat-signed (RHEL) 6 packages
+that have broken dependencies. The script also fixes possible broken
+dependencies of the newly installed packages.
 
 The following packages are no longer available:" >solution.txt
 
@@ -87,7 +87,7 @@ vendor to provide an alternative solution, or you may get the missing package fr
 other sources than Red Hat Enterprise Linux.
 
 " >>solution.txt
-[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux 7, there are still some el6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run manually the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script after the upgrade to remove only old native packages with broken dependencies."
+[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux (RHEL) 7, there are still some RHEL 6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script manually after the upgrade to remove only those Red Hat-signed RHEL 6 packages that have broken dependencies."
 
 [ $found -eq 1 ] && log_medium_risk "\
 Some packages installed on the system were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break the functionality of the packages that depend on the removed packages." && exit $RESULT_FAIL

--- a/RHEL6_7/packages/RemovedPackages/check
+++ b/RHEL6_7/packages/RemovedPackages/check
@@ -17,13 +17,24 @@ cat "$COMMON_DIR"/default*_removed* | grep -v "\.so" | cut -f1 -d' ' | sort | un
   exit $RESULT_ERROR
 
 SCRIPT_NAME="postupgrade_cleanup.sh"
+NOAUTO_SCRIPT_NAME="native_rpm_dep_fix.sh"
 POSTUPGRADE_DIR="$VALUE_TMP_PREUPGRADE/postupgrade.d/clean_rhel6_pkgs"
+NOAUTO_POST_DIR="$VALUE_TMP_PREUPGRADE/noauto_postupgrade.d/rpmfix"
 POST_SCRIPT="postupgrade.d/$SCRIPT_NAME"
+NOAUTO_POST_SCRIPT="noauto_postupgrade.d/$NOAUTO_SCRIPT_NAME"
+
 if [ ! -d "$POSTUPGRADE_DIR" ]; then
     mkdir -p "$VALUE_TMP_PREUPGRADE/postupgrade.d/clean_rhel6_pkgs"
 fi
+
+if [ ! -d "$NOAUTO_POST_DIR" ]; then
+    mkdir -p "$NOAUTO_POST_DIR"
+fi
+
 cp $POST_SCRIPT $POSTUPGRADE_DIR/$SCRIPT_NAME
+cp $NOAUTO_POST_SCRIPT $NOAUTO_POST_DIR/$SCRIPT_NAME
 get_dist_native_list > $POSTUPGRADE_DIR/$(basename $VALUE_RPM_RHSIGNED)
+cp "$POSTUPGRADE_DIR/$(basename $VALUE_RPM_RHSIGNED)" "$NOAUTO_POST_DIR"
 
 found=0
 rm -f solution.txt
@@ -31,6 +42,12 @@ echo \
 "Some packages were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break
 the upgrade for some of your packages. We are not aware of any compatible
 replacement for these packages.
+
+Use the '--cleanup-post' option of redhat-upgrade-tool to remove them
+automatically during upgrade. You can also run manually the $sssscript script
+after the upgrade to remove only the original native packages with broken
+dependencies. The script also fixes possible broken dependencies of the newly
+installed packages.
 
 The following packages are no longer available:" >solution.txt
 
@@ -68,8 +85,9 @@ echo \
 If a package not signed by Red Hat requires these packages, you may need to ask your
 vendor to provide an alternative solution, or you may get the missing package from
 other sources than Red Hat Enterprise Linux.
+
 " >>solution.txt
-[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux 7, there are still some el6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically."
+[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux 7, there are still some el6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run manually the $sssscript script after the upgrade to remove only old native packages with broken dependencies."
 
 [ $found -eq 1 ] && log_medium_risk "\
 Some packages installed on the system were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break the functionality of the packages that depend on the removed packages." && exit $RESULT_FAIL

--- a/RHEL6_7/packages/RemovedPackages/check
+++ b/RHEL6_7/packages/RemovedPackages/check
@@ -44,7 +44,7 @@ the upgrade for some of your packages. We are not aware of any compatible
 replacement for these packages.
 
 Use the '--cleanup-post' option of redhat-upgrade-tool to remove them
-automatically during upgrade. You can also run manually the $sssscript script
+automatically during upgrade. You can also run manually the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script
 after the upgrade to remove only the original native packages with broken
 dependencies. The script also fixes possible broken dependencies of the newly
 installed packages.
@@ -87,7 +87,7 @@ vendor to provide an alternative solution, or you may get the missing package fr
 other sources than Red Hat Enterprise Linux.
 
 " >>solution.txt
-[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux 7, there are still some el6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run manually the $sssscript script after the upgrade to remove only old native packages with broken dependencies."
+[ $found -eq 1 ] && log_high_risk "After upgrading to Red Hat Enterprise Linux 7, there are still some el6 packages left. Add the '--cleanup-post' option to redhat-upgrade-tool to remove them automatically. You can also run manually the $NOAUTO_POST_DIR/$NOAUTO_SCRIPT_NAME script after the upgrade to remove only old native packages with broken dependencies."
 
 [ $found -eq 1 ] && log_medium_risk "\
 Some packages installed on the system were removed between Red Hat Enterprise Linux 6 and Red Hat Enterprise Linux 7. This might break the functionality of the packages that depend on the removed packages." && exit $RESULT_FAIL

--- a/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
+++ b/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#RHSIGNED_PKGS="/var/cache/preupgrade/common/rpm_rhsigned.log"
+RHSIGNED_PKGS="rpm_rhsigned.log"
+kept_broken_rpms="kept_broken_rpms"
+
+log_error() {
+    echo >&2 "Error: $@"
+}
+
+get_broken_deps_list() {
+    rpm -Va --nofiles \
+        | grep -i "^Unsatisfied" \
+        | sed "s/^Unsatisfied dependencies for //" \
+        | sed "s/:$//" \
+        | sort \
+        | uniq
+}
+
+is_dist_native() {
+    grep -qE "^$1([[:space:]]|$)" "$RHSIGNED_PKGS"
+}
+
+rm_native_broken_old_rpms() {
+    get_broken_deps_list | grep "\.el6" > rpms_broken
+    local REMOVED_FLAG=0
+    local line=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        # ###
+        NAME=$(rpm -q --qf '%{NAME}' $line)
+        is_dist_native "$NAME" || {
+            # it's not dist native package -> skip it
+            echo "    $NAME" >> "$kept_broken_rpms"
+            continue
+        }
+
+        # remove broken rpm
+        rpm -e --nodeps "$line" || {
+            rpm -q "$line" >/dev/null 2>&1 \
+                && log_error "The $line RPM has not been removed."
+            continue
+        }
+        REMOVED_FLAG=1
+    done < rpms_broken
+    return $REMOVED_FLAG
+}
+
+
+##################### MAIN ###########################
+cd $(dirname "$0")
+rm -f "$kept_broken_rpms"
+touch "$kept_broken_rpms"
+
+for counter in {0..10}; do
+    # try just limited number of loops in most to be sure that scripts ends
+    # always (in reasonable time)
+    # .. in case that nothing is removed (returned 0) skip the loop
+    rm_native_broken_old_rpms && break
+done
+
+broken_nonnative_rpms=$(wc -l <"$kept_broken_rpms")
+[ $broken_nonnative_rpms -gt 0 ] && {
+    echo >&2 "WARNING: Detected several non-native RPMs with broken dependencies:"
+    cat "$kept_broken_rpms" | sort | uniq >&2
+}
+
+# check RHEL 7 packages for broken dependencies and try to install all missing
+# dependencies:
+get_broken_deps_list | grep "\.el7" > rpms_broken
+while IFS= read -r line || [ -n "$line" ]; do
+    yum reinstall "$line" -y || {
+        echo >&2 "Error: The $line RPM with broken dependencies cannot be reinstalled."
+    }
+done < rpms_broken
+

--- a/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
+++ b/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
@@ -3,9 +3,16 @@
 #RHSIGNED_PKGS="/var/cache/preupgrade/common/rpm_rhsigned.log"
 RHSIGNED_PKGS="rpm_rhsigned.log"
 kept_broken_rpms="kept_broken_rpms"
+VERBOSE=0
+RM_CUSTOM_RPM=0
+FAIL=0
 
-log_error() {
-    echo >&2 "Error: $@"
+log_error()   { echo >&2 "Error:   $@"; }
+log_warning() { echo >&2 "Warning: $@"; }
+log_info()    { echo >&2 "Info:    $@"; }
+
+log_info_verbose() {
+    [ 0"$VERBOSE" -eq 1 ] && log_info "$@"
 }
 
 get_broken_deps_list() {
@@ -22,22 +29,33 @@ is_dist_native() {
 }
 
 rm_native_broken_old_rpms() {
+    #
+    # Remove native RPMs with broken dependencies.
+    #
+    # The function can be affected by the $RM_CUSTOM_RPM variable to remove
+    # even non-native RPMs.
+    #
+    # Return 0 when no RPM has been removed. Otherwise returns 1.
+    #
     get_broken_deps_list | grep "\.el6" > rpms_broken
     local REMOVED_FLAG=0
     local line=""
     while IFS= read -r line || [ -n "$line" ]; do
-        # ###
         NAME=$(rpm -q --qf '%{NAME}' $line)
-        is_dist_native "$NAME" || {
+        is_dist_native "$NAME" || [ $RM_CUSTOM_RPM -eq 1 ] || {
             # it's not dist native package -> skip it
             echo "    $NAME" >> "$kept_broken_rpms"
+            log_info_verbose "Skip the non-native $line RPM."
             continue
         }
 
         # remove broken rpm
+        log_info_verbose "Removing the $line RPM."
         rpm -e --nodeps "$line" || {
-            rpm -q "$line" >/dev/null 2>&1 \
-                && log_error "The $line RPM has not been removed."
+            rpm -q "$line" >/dev/null 2>&1 || {
+                log_error "The $line RPM has not been removed."
+                FAIL=1
+            }
             continue
         }
         REMOVED_FLAG=1
@@ -47,21 +65,56 @@ rm_native_broken_old_rpms() {
 
 
 ##################### MAIN ###########################
+
+# process params from cmdln
+while [[ -n "$1" ]]; do
+    case $1 in
+        -a | --rm-all)
+            RM_CUSTOM_RPM=1
+            ;;
+        -v | --verbose)
+            VERBOSE=1
+            ;;
+        -h | --help)
+            echo "USAGE: native_rpm_dep_fix [-a|--rm-all] [-v|--verbose] [-h|--help]"
+            echo "    -a | --rm-all   Enable remove of non-native RPMs"
+            echo "    -v | --verbose  Activate verbose mode"
+            echo "    -h | --help     Print this help"
+            echo
+            exit 0
+            ;;
+    esac
+    shift
+done
+
+
 cd $(dirname "$0")
 rm -f "$kept_broken_rpms"
 touch "$kept_broken_rpms"
 
+[ $RM_CUSTOM_RPM -eq 1 ] \
+    && log_info_verbose "Remove of non-native conflicting RPMs has been enabled."
+
 for counter in {0..10}; do
     # try just limited number of loops in most to be sure that scripts ends
     # always (in reasonable time)
-    # .. in case that nothing is removed (returned 0) skip the loop
+    # .. in case that nothing is removed (returned 0) break the loop
     rm_native_broken_old_rpms && break
+    [ $counter -eq 10 ] && {
+        [ -z "$(get_broken_deps_list)" ] && {
+            log_warning "Reached iteration limit but some RPMs are still broken."
+            log_info "You can run the application again to try to remove rest of RPMs."
+            FAIL=1
+        }
+    }
 done
 
 broken_nonnative_rpms=$(wc -l <"$kept_broken_rpms")
 [ $broken_nonnative_rpms -gt 0 ] && {
-    echo >&2 "WARNING: Detected several non-native RPMs with broken dependencies:"
+    # this is obviously irrelevant in case of use the -a option
+    log_warning "Detected several non-native RPMs with broken dependencies:"
     cat "$kept_broken_rpms" | sort | uniq >&2
+    log_info "You can use the '-a' option to enable remove of non-native RPMs."
 }
 
 # check RHEL 7 packages for broken dependencies and try to install all missing
@@ -69,7 +122,10 @@ broken_nonnative_rpms=$(wc -l <"$kept_broken_rpms")
 get_broken_deps_list | grep "\.el7" > rpms_broken
 while IFS= read -r line || [ -n "$line" ]; do
     yum reinstall "$line" -y || {
-        echo >&2 "Error: The $line RPM with broken dependencies cannot be reinstalled."
+        log_error "The $line RPM with broken dependencies cannot be reinstalled."
+        FAIL=1
     }
 done < rpms_broken
+
+exit $FAIL
 

--- a/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
+++ b/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
@@ -49,7 +49,7 @@ rm_broken_old_rpms() {
         is_dist_native "$NAME" || [ $rm_custom_enabled -eq 1 ] || {
             # it's not dist native package -> skip it
             echo "    $NAME" >> "$kept_broken_rpms"
-            log_info_verbose "Skip the non-native $line RPM."
+            log_info_verbose "Skip the 3rd party of custom $line RPM."
             continue
         }
 
@@ -81,7 +81,7 @@ while [[ -n "$1" ]]; do
             ;;
         -h | --help)
             echo "USAGE: native_rpm_dep_fix [-a|--rm-all] [-v|--verbose] [-h|--help]"
-            echo "    -a | --rm-all   Enable remove of non-native RPMs"
+            echo "    -a | --rm-all   Enable removal of 3rd party or custom RPMs"
             echo "    -v | --verbose  Activate verbose mode"
             echo "    -h | --help     Print this help"
             echo
@@ -97,7 +97,7 @@ rm -f "$kept_broken_rpms"
 touch "$kept_broken_rpms"
 
 [ $RM_CUSTOM_RPM -eq 1 ] \
-    && log_info_verbose "Remove of non-native conflicting RPMs has been enabled."
+    && log_info_verbose "Removal of 3rd party or custom RPMs with broken dependencies has been enabled."
 
 for counter in {0..10}; do
     # try just limited number of loops in most to be sure that scripts ends
@@ -116,9 +116,9 @@ done
 broken_nonnative_rpms=$(wc -l <"$kept_broken_rpms")
 [ $broken_nonnative_rpms -gt 0 ] && {
     # this is obviously irrelevant in case of use the -a option
-    log_warning "Detected several non-native RPMs with broken dependencies:"
+    log_warning "Detected several 3rd party or custom RHEL 6 RPMs with broken dependencies:"
     cat "$kept_broken_rpms" | sort | uniq >&2
-    log_info "You can use the '-a' option to enable remove of non-native RPMs."
+    log_info "You can use the '-a' option to enable removal of 3rd party or custom RPMs."
 }
 
 # check RHEL 7 packages for broken dependencies and try to install all missing

--- a/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
+++ b/RHEL6_7/packages/RemovedPackages/noauto_postupgrade.d/native_rpm_dep_fix.sh
@@ -7,12 +7,12 @@ VERBOSE=0
 RM_CUSTOM_RPM=0
 FAIL=0
 
-log_error()   { echo >&2 "Error:   $@"; }
-log_warning() { echo >&2 "Warning: $@"; }
-log_info()    { echo >&2 "Info:    $@"; }
+log_error()   { echo >&2 "Error:   $1"; }
+log_warning() { echo >&2 "Warning: $1"; }
+log_info()    { echo >&2 "Info:    $1"; }
 
 log_info_verbose() {
-    [ 0"$VERBOSE" -eq 1 ] && log_info "$@"
+    [ 0"$VERBOSE" -eq 1 ] && log_info "$1"
 }
 
 get_broken_deps_list() {
@@ -80,7 +80,7 @@ while [[ -n "$1" ]]; do
             VERBOSE=1
             ;;
         -h | --help)
-            echo "USAGE: native_rpm_dep_fix [-a|--rm-all] [-v|--verbose] [-h|--help]"
+            echo "USAGE: ${0##*/} [-a|--rm-all] [-v|--verbose] [-h|--help]"
             echo "    -a | --rm-all   Enable removal of 3rd party or custom RPMs"
             echo "    -v | --verbose  Activate verbose mode"
             echo "    -h | --help     Print this help"


### PR DESCRIPTION
In case user doesn't use --cleanup-post option in r-u-t, there could be kept broken el6 packages which could inhibit user to update their package set. This script can be run by user manually to resolve such issues, keeping non-native packages untouched.