### PR TITLE
 semanage_export fix syntax

### DIFF
--- a/RHEL6_7/selinux/RestoreConfig/postupgrade.d/restoreConfig.sh
+++ b/RHEL6_7/selinux/RestoreConfig/postupgrade.d/restoreConfig.sh
@@ -15,7 +15,14 @@ semanage_syntax_update() {
 
     for ftype_opt in "${ftype_opts[@]}"
     do
-        sed -i -r 's/'"$ftype_opt"'\s+directory/'"$ftype_opt"' d/g' "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)?directory(\x27|\x22)?/$ftype_opt d/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)all\s+files(\x27|\x22)/$ftype_opt a/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)character\s+device(\x27|\x22)/$ftype_opt c/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)block\s+device(\x27|\x22)/$ftype_opt b/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)regular\s+file(\x27|\x22)/$ftype_opt f/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)?socket(\x27|\x22)?/$ftype_opt s/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)symbolic\s+link(\x27|\x22)/$ftype_opt l/g" "$file"
+        sed -i -r "s/$ftype_opt\s+(\x27|\x22)named\s+pipe(\x27|\x22)/$ftype_opt p/g" "$file"
     done
 }
 

--- a/RHEL6_7/selinux/RestoreConfig/postupgrade.d/restoreConfig.sh
+++ b/RHEL6_7/selinux/RestoreConfig/postupgrade.d/restoreConfig.sh
@@ -2,7 +2,26 @@
 
 SEMANAGE_EXPORT_FILE=semanage_export
 
+semanage_syntax_update() {
+
+    ftype_opts=( '-f' '--ftype')
+    bool_opts=( '-1' '-0' '--on' '--off' )
+    local file=$1
+
+    for opt in "${bool_opts[@]}"
+    do
+        sed -i -r 's/'"$opt"'/-m '"$opt"'/g' "$file"
+    done
+
+    for ftype_opt in "${ftype_opts[@]}"
+    do
+        sed -i -r 's/'"$ftype_opt"'\s+directory/'"$ftype_opt"' d/g' "$file"
+    done
+}
+
+
 if test -s "$SEMANAGE_EXPORT_FILE"; then
+    semanage_syntax_update "$SEMANAGE_EXPORT_FILE"
     while read -r line
     do
         # restore saved configuration line by line


### PR DESCRIPTION
 - updating syntax of semanage_export file to
   conform to the RHEL 7 semanage syntax
   

With this fix , postupgrade script restoreConfig.sh is updated, so it updates the command line arguments to semanage in the semanage_export file to RHEL 7 syntax. 
There is no comprehensive list of deprecated options I'm aware of ( man pages are not 100% reliable in this case), so at the moment, only known issues are handled.

Resolves #39