### PR TITLE
system/java: handle i686/i386 rpm

### DIFF
--- a/RHEL6_7/system/java/check
+++ b/RHEL6_7/system/java/check
@@ -55,6 +55,17 @@ get_jvm_dir() {
   name_ver=$(echo "$rpm_name" | rev | cut -d "-" -f 2- | rev)
   aarch=$(echo "$rpm_name" | rev | cut -d "." -f 1 | rev)
 
+  [ "$aarch" == "i686" ] && {
+    [ -e "/usr/lib/jvm/${name_ver}.${aarch}" ] || {
+      # BUGFIX: in case of i686 arch java rpms there is some building magic
+      #         and arch of the files of the rpms has different "arch" than
+      #         the one used for name of the rpm itself. Probably the check of
+      #         existence of the file is not needed in current state, but
+      #         rather do that just in case it would be modified in future.
+      aarch="i386"
+    }
+  }
+
   echo "/usr/lib/jvm/${name_ver}.${aarch}"
 }
 


### PR DESCRIPTION
In case the java for i686 arch is installed, we need to handle issue when files inside use arch "i386" instead of "i686". It's a black magic. Just use arch-name "i386" when expected jvm dir with "i686" doesn't exist.

Resolves: #76

Testing is not required here for merge as systems should not be affected by this change unless the weird "i686" java is installed on 64b system (which is really weird on RHEL systems).