### PR TITLE
system/grubby - exit not applicable on ppc64 architecture

### DIFF
--- a/RHEL6_7/system/grubby/check
+++ b/RHEL6_7/system/grubby/check
@@ -7,6 +7,7 @@ ARCH="$(arch)"
 
 # grub is not supported on s390x machines
 [ "$ARCH" == "s390x" ] && exit_not_applicable
+[ "$ARCH" == "ppc64" ] && exit_not_applicable
 
 DIR=grubby_workaround
 FILE=postupgrade.sh


### PR DESCRIPTION
On the ppc64 architecture on RHEL 6 system is allowed only the Yaboot bootloader which is replaced during the upgrade by the GRUB2 bootloader.

Relevant to RHBZ#1278675 (see the #4 comment):
  https://bugzilla.redhat.com/show_bug.cgi?id=1278675
Fixes: #87