### PR TITLE
Bump to version 0.7.4

### DIFF
--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -4,7 +4,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
 Name:           preupgrade-assistant-el6toel7
-Version:        0.7.3
+Version:        0.7.4
 Release:        1%{?dist}
 Summary:        Set of modules created for upgrade to Red Hat Enterprise Linux 7
 Group:          System Environment/Libraries

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
-Version 0.7.3
+Version 0.7.4
 DataVersion 0
 6.10-7.5


### PR DESCRIPTION
- set upgrade path RHEL 6.10 -> RHEL 7.6
- rename correctly netowrk interfaces regardless amount of existing
  interfaces
- initscripts/ifcfg: set the -E option for grep to process EREG
  correctly (#84)
- system/java: handle corerectly i686 RPMs (#76)
- system/grubby: set as not applicable on ppc64 arch