### PR TITLE
Network scripts

### DIFF
--- a/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
+++ b/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
@@ -76,7 +76,7 @@ do
         fi
     fi
 
-    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", $mac_rule, $dev_type_rule, KERNEL==\"${orig_name_base}*\", NAME=\"$new_full_name\"\n" >> udev_temp
+    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", $mac_rule, $dev_type_rule, NAME=\"$new_full_name\"\n" >> udev_temp
 
 done
 

--- a/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
+++ b/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
@@ -33,7 +33,7 @@ cat /dev/null > "$preupg_script"
 echo '#!/bin/bash' >> "$preupg_script"
 echo 'service network stop'  >> "$preupg_script"
 
-if ls "$dev_path" | grep -q "rename[0-9]+$";then
+if ls "$dev_path" | grep -q -E "rename[0-9]+$";then
     exit 1
 fi
 


### PR DESCRIPTION
With this PR, issue of the systemd causing interfaces to be renamed inconsistently during the initramdisk phase  is resolved.
