### PR TITLE
 system/initscripts/ifcfg - edit udev rules,style enhancement

### DIFF
--- a/RHEL6_7/system/initscripts/ifcfg/check
+++ b/RHEL6_7/system/initscripts/ifcfg/check
@@ -140,10 +140,10 @@ I case 3, to be completely correct you could check that user is not using rhel7 
                 log_slight_risk(full_path + " variable DEVICE is similar to udev predictable network naming scheme. It might cause conflicts.")
                 warning = True
 
-        if ethx_with_addr_count > 1 or ethx_without_addr_count > 1:
+        if ( ethx_with_addr_count  + ethx_without_addr_count) > 1:
             ifnames_to_fix +=1
             warning = True
-        elif ethx_with_addr_count == 1:
+        elif( ethx_with_addr_count + ethx_without_addr_count) == 1:
             log_slight_risk("You use one network device with an old style 'ethX' name.")
             warning = True
 

--- a/RHEL6_7/system/initscripts/ifcfg/check
+++ b/RHEL6_7/system/initscripts/ifcfg/check
@@ -106,9 +106,9 @@ I case 3, to be completely correct you could check that user is not using rhel7 
         script_result.communicate()
         exit_code = script_result.returncode
         if exit_code == 1:
-            log_extreme_risk("The network interface names on the source system are in an inconsistent state, so the upgrade is not possible")
+            log_high_risk("The network interface names on the source system are in an inconsistent state, so the upgrade is not possible")
         elif exit_code == 2:
-            log_extreme_risk("Comment out the MACADDR directive in the ifcfg files and run the Preupgrade Assistant again to enable the upgrade.")
+            log_high_risk("Comment out the MACADDR directive in the ifcfg files and run the Preupgrade Assistant again to enable the upgrade.")
 
     ethx_with_addr_count = 0
     ethx_without_addr_count = 0

--- a/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
+++ b/RHEL6_7/system/initscripts/ifcfg/preupg_network.sh
@@ -76,7 +76,7 @@ do
         fi
     fi
 
-    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", $mac_rule, $dev_type_rule, KERNEL==\"${orig_name_base}*\", NAME=\"$new_full_name\"\n" >> udev_temp
+    echo -e "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", $mac_rule, $dev_type_rule, NAME=\"$new_full_name\"\n" >> udev_temp
 
 done
 


### PR DESCRIPTION
 - the code generating the udev rules was adjusted
   to remove the "kernel" parameter in order
   to disable the unwanted renaming in the
   initramdisk phase.
- style enhancement 
     - the log_extreme_risk is replaced by
       combination of log_high_risk and
       pre-upgrade script, that inhibits
       upgrade.
     - the script preupg_network.sh has
       been edited to use the variables
       provided by PA API when reasonable.
     - Solution text has been edited to
       inform the user about custom naming
       option.

Resolves #72 