### PR TITLE
 services/tomcat

### DIFF
--- a/RHEL6_7/services/tomcat/post-tomcat.py
+++ b/RHEL6_7/services/tomcat/post-tomcat.py
@@ -213,14 +213,14 @@ def mv_webapps():
             )
         return False
     if (os.system("/bin/mv %s %s-preupg-backup"
-                  % (APP_WEB_HOME_NEW, APP_WEB_HOME_NEW))):
+                  % (APP_WEB_HOME_NEW, APP_WEB_HOME_NEW))) != 0:
         log_error(
             "The %s directory has not been backed up and the"
             " web apps from tomcat6 cannot be moved. Migrate your web"
             " applications manually." % APP_WEB_HOME_NEW
             )
         return False
-    if os.system("/bin/mv %s %s" % (APP_WEB_HOME, APP_WEB_HOME_NEW)):
+    if os.system("/bin/mv %s %s" % (APP_WEB_HOME, APP_WEB_HOME_NEW)) != 0:
         log_error(
             "Original web applications inside the %s directory have not been moved to the new"
             " %s directory, so tomcat cannot be used with them as it was before."
@@ -243,13 +243,15 @@ def mv_configs():
     Copy modified configuration files of tomcat6 to new destinations.
     """
     # ok, this generate "//" in logs but doesn't matter
-    if os.system("/bin/mv -vf %s/* %s" % (CONFIG_DIR, "/etc/tomcat")):
+    if os.system("/bin/cp -avr %s/* %s" % (CONFIG_DIR, "/etc/tomcat")) != 0:
         log_error(
             "The tomcat6 configuration files have not been moved to the new tomcat"
             "directory. Move the files manually.")
         return False
-
-    return True
+    else:
+        if os.path.isdir(CONFIG_DIR):
+            os.system("/usr/bin/rm -rf %s" % CONFIG_DIR)
+        return True
 
 ##############################################################################
 ##### MAIN #####
@@ -356,7 +358,7 @@ status |= mv_configs()
 # remove old packages
 for pkg in old_packages:
     if os.system("rpm -q %s >/dev/null" % pkg) == 0:
-        if os.system("rpm -e --nodeps %s" % old_packages):
+        if os.system("rpm -e --nodeps %s" % pkg) != 0:
             log_error(
                 "The %s package has not been removed from the system."
                 " Remove the package manually." % pkg

--- a/RHEL6_7/services/tomcat/post-tomcat.py
+++ b/RHEL6_7/services/tomcat/post-tomcat.py
@@ -38,6 +38,9 @@ def get_lines(fname):
         lines = map(lambda x: x.strip(), handle.readlines())
     return lines
 
+def log_info(msg):
+    sys.stderr.write("Info: %s\n" % msg)
+
 def log_error(msg):
     sys.stderr.write("Error: %s\n" % msg)
 
@@ -243,6 +246,13 @@ def mv_configs():
     Copy modified configuration files of tomcat6 to new destinations.
     """
     # ok, this generate "//" in logs but doesn't matter
+    if not os.path.isdir(CONFIG_DIR):
+        log_info(
+            "Original system used the default tomcat6 configuration."
+            " Using the default configuration of the tomcat of the target"
+            " system."
+            )
+        return True
     if os.system("/bin/cp -avr %s/* %s" % (CONFIG_DIR, "/etc/tomcat")) != 0:
         log_error(
             "The tomcat6 configuration files have not been moved to the new tomcat"

--- a/RHEL6_7/services/tomcat/post-tomcat.py
+++ b/RHEL6_7/services/tomcat/post-tomcat.py
@@ -7,8 +7,16 @@ import xml.ElementTree as ET
 from shutil import copy2
 
 ##### FUNC + CONST / GLOBVARS #####
-APP_WEB_HOME="/usr/share/tomcat6/webapps"
-APP_WEB_HOME_NEW="/usr/share/tomcat/webapps"
+#TODO: Original APP_WEB_HOME* paths contains symlinks to the paths that are
+#      used below now. However, this is hardcoded solution which does not have
+#      to be correct. The original symlink of tomcat6 is removed before the
+#      post-upgrade script is processed now. So this is temporary solution that
+#      will resolve the migrating issue for now and better solution should be
+#      delivered in future.
+#APP_WEB_HOME="/usr/share/tomcat6/webapps"
+#APP_WEB_HOME_NEW="/usr/share/tomcat/webapps"
+APP_WEB_HOME="/var/lib/tomcat6/webapps"
+APP_WEB_HOME_NEW="/var/lib/tomcat/webapps"
 CONFIG_DIR="/etc/tomcat6/"
 
 GLOBAL_CONFIG_FILE = os.path.join(CONFIG_DIR, "server.xml")


### PR DESCRIPTION
 - adding explicit check for return values when
   calling os.system().
 - replacing 'mv' command for 'cp' && 'rm' when
   merging directories to avoid errors.
 - fixing error in iteration of old_packages list.