### PR TITLE
system/java-1.8.0-ibm - check for package being present before update

### DIFF
--- a/RHEL6_7/system/java-1.8.0-ibm/check
+++ b/RHEL6_7/system/java-1.8.0-ibm/check
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from preupg.script_api import *
+
+#END GENERATED SECTION
+
+import os
+from shutil import copy2
+
+# This script will be used during pre-upgrade section of redhat-upgrade-tool
+# when 'java-1.8.0-ibm' is found.
+PRE_UPGRADE_SCRIPT = "remove-java-1.8.0-ibm-pre-upgrade.sh"
+PRE_UPGRADE_DIR    = os.path.join(VALUE_TMP_PREUPGRADE, "preupgrade-scripts")
+
+##############################################################################
+##### MAIN #####
+##############################################################################
+
+log_high_risk("The java-1.8.0-ibm package is installed."
+              " Remove it before the in-place upgrade.")
+solution_file("The java-1.8.0-ibm package is installed and conflicts with"
+              " the upgrade. Remove the package before the upgrade.\n")
+
+# add pre-upgrade check script, which check, that package was really
+# removed before upgrade - otherwise user can't continue in upgrade.
+copy2(PRE_UPGRADE_SCRIPT, PRE_UPGRADE_DIR)
+os.chmod(os.path.join(PRE_UPGRADE_DIR, PRE_UPGRADE_SCRIPT), 775)
+
+exit_fail()

--- a/RHEL6_7/system/java-1.8.0-ibm/module.ini
+++ b/RHEL6_7/system/java-1.8.0-ibm/module.ini
@@ -1,0 +1,6 @@
+[preupgrade]
+content_description = The module checks for incompatibility between java-1.8.0-ibm package in Red Hat Enterprise Linux 6 and same package in Red Hat Enterprise Linux 7.
+content_title = java-1.8.0-ibm compatibility check
+author = Renaud Métrich <rmetrich@redhat.com>
+applies_to = java-1.8.0-ibm
+bugzilla = 1620589, 1613756

--- a/RHEL6_7/system/java-1.8.0-ibm/module_spec
+++ b/RHEL6_7/system/java-1.8.0-ibm/module_spec
@@ -1,0 +1,18 @@
+==============================================================================
+The module specification:
+==============================================================================
+
+Root cause
+----------
+java-1.8.0-ibm on RHEL 6 is not compatible with RHEL 7. The package must be
+removed otherwise 'alternatives' symlinks will be broken upon package update,
+preventing to run java properly.
+Also, reinstalling or updating the package once upgraded to RHEL 7 will
+continuously fail, unless instructions in KCS
+https://access.redhat.com/site/solutions/3556401 are followed.
+
+
+short story long:
+-----------------
+The module is applied when java-1.8.0-ibm is installed. It always returns FAIL
+(high risk + exit fail).

--- a/RHEL6_7/system/java-1.8.0-ibm/remove-java-1.8.0-ibm-pre-upgrade.sh
+++ b/RHEL6_7/system/java-1.8.0-ibm/remove-java-1.8.0-ibm-pre-upgrade.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if rpm -q java-1.8.0-ibm >/dev/null 2>&1; then
+  {
+    echo -n "Error: A java-1.8.0-ibm package has been found installed on the system."
+    echo -n " The package must be removed before the upgrade to a new system."
+    echo " See the report from the Preupgrade Assistant."
+  } >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
java-1.8.0-ibm EL6 is incompatible with EL7. Upon update, this causes broken symlinks to persist and makes Java unusable.