### PR TITLE
Silence grep test for AuthorizedKeysCommand

### DIFF
--- a/RHEL6_7/networking/openssh-keycat/check
+++ b/RHEL6_7/networking/openssh-keycat/check
@@ -3,7 +3,7 @@
 
 #END GENERATED SECTION
 
-grep -E "^\s*AuthorizedKeysCommand\s+/usr/libexec/openssh/ssh-keycat" /etc/ssh/sshd_config
+grep -qE "^\s*AuthorizedKeysCommand\s+/usr/libexec/openssh/ssh-keycat" /etc/ssh/sshd_config
 
 [[ $? -ne 0 ]] && {
   log_medium_risk "The ssh-keycat files are moved to the openssh-keycat package."


### PR DESCRIPTION
Modules are not supposed to generate stdout or stderr on their own.