### PR TITLE
fix used modes for os.chmod in python's scripts

### DIFF
--- a/RHEL6_7/services/tomcat/check
+++ b/RHEL6_7/services/tomcat/check
@@ -528,7 +528,7 @@ if is_pkg_installed("tomcat"):
     # add pre-upgrade check script, which check, that package was really
     # removed before upgrade - otherwise user can't continue in upgrade.
     copy2(PRE_UPGRADE_SCRIPT, PRE_UPGRADE_DIR)
-    os.chmod(os.path.join(PRE_UPGRADE_DIR, PRE_UPGRADE_SCRIPT), 0775)
+    os.chmod(os.path.join(PRE_UPGRADE_DIR, PRE_UPGRADE_SCRIPT), 0o775)
 
 
 ##### now apply all checks implemented above #####
@@ -566,7 +566,7 @@ try:
     copy2("xml/ElementTree.py", os.path.join(PRIVATE_POST_DIR, "xml"))
     copy2("xml/__init__.py", os.path.join(PRIVATE_POST_DIR, "xml"))
     copy2(POST_SCRIPT, PRIVATE_POST_DIR)
-    os.chmod(os.path.join(PRIVATE_POST_DIR, POST_SCRIPT), 0755)
+    os.chmod(os.path.join(PRIVATE_POST_DIR, POST_SCRIPT), 0o755)
 except IOError as e:
     log_error("IOError: %s %s" % (e.strerror, e.filename))
     _set_exit_func(exit_error)

--- a/RHEL6_7/system/java-1.8.0-ibm/check
+++ b/RHEL6_7/system/java-1.8.0-ibm/check
@@ -25,6 +25,6 @@ solution_file("The java-1.8.0-ibm package is installed and conflicts with"
 # add pre-upgrade check script, which check, that package was really
 # removed before upgrade - otherwise user can't continue in upgrade.
 copy2(PRE_UPGRADE_SCRIPT, PRE_UPGRADE_DIR)
-os.chmod(os.path.join(PRE_UPGRADE_DIR, PRE_UPGRADE_SCRIPT), 775)
+os.chmod(os.path.join(PRE_UPGRADE_DIR, PRE_UPGRADE_SCRIPT), 0o775)
 
 exit_fail()


### PR DESCRIPTION
In python, use of 0xxx mode is incorrect. Either xxx is wrong as
mode is not set as expected. Only correct way here is use of 0oxxx
format. E.g.:
        0o775