### PR TITLE
Bump to version 0.7.6

### DIFF
--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -4,7 +4,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
 Name:           preupgrade-assistant-el6toel7
-Version:        0.7.5
+Version:        0.7.6
 Release:        1%{?dist}
 Summary:        Set of modules created for upgrade to Red Hat Enterprise Linux 7
 Group:          System Environment/Libraries

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
-Version 0.7.5
+Version 0.7.6
 DataVersion 0
-6.10-7.5
+6.10-7.6


### PR DESCRIPTION
- system/pam: fixes hanging in specific cases and improves report
- system/BinariesRebuild: fixes issues with empty blacklist file
- backup configuration files only into dirtyconf and cleanconf dirs
- add module to inhibit upgrade when system/java-1.8.0-ibm is installed
- fixes chmods when it is handled in python scripts