### PR TITLE
system/tuned: updated the check, added more rules

### DIFF
--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -4,6 +4,15 @@
 
 #END GENERATED SECTION
 
+FILES=$(rpm -ql tuned 2> /dev/null) && HAS_TUNED=1
+VERIFY=$(rpm -qV tuned 2> /dev/null)
+FILES="$FILES $(rpm -ql tuned-profiles-sap 2> /dev/null)"
+VERIFY="$VERIFY $(rpm -qV tuned-profiles-sap 2> /dev/null)"
+FILES="$FILES $(rpm -ql tuned-profiles-sap-hana 2> /dev/null)"
+VERIFY="$VERIFY $(rpm -qV tuned-profiles-sap-hana 2> /dev/null)"
+FILES="$FILES $(rpm -ql tuned-profiles-oracle 2> /dev/null)"
+VERIFY="$VERIFY $(rpm -qV tuned-profiles-oracle 2> /dev/null)"
+
 TUNED_DIR="/etc/tune-profiles/"
 if [[ -d "$TUNED_DIR" ]]; then
     POSTUPGRADE_TUNED_DIR="$VALUE_TMP_PREUPGRADE/postupgrade.d/tuned"
@@ -11,13 +20,58 @@ if [[ -d "$TUNED_DIR" ]]; then
         mkdir -p "$POSTUPGRADE_TUNED_DIR"
     fi
 
+    RES=$RESULT_FAIL
+    if [ -f /etc/tune-profiles/active-profile ]; then
+        ACTIVE_PROFILE=$(cat /etc/tune-profiles/active-profile)
+        case "$ACTIVE_PROFILE" in
+        "default")
+            ACTIVE_PROFILE="balanced"
+            log_medium_risk "Your Tuned profile 'default' is no longer supported, switched to the replacement profile 'balanced'."
+            ;;
+        "throughput-performance" | "latency-performance" | "virtual-guest" | "virtual-host" | \
+        "sap-netweaver" | "sap-hana" | "sap-hana-vmware" | "oracle")
+            RES=$RESULT_PASS
+            ;;
+        "laptop-ac-powersave" | "laptop-battery-powersave" | "server-powersave")
+            log_medium_risk "Your Tuned profile '$ACTIVE_PROFILE' is no longer supported, switched to the replacement profile 'powersave'."
+            ACTIVE_PROFILE="powersave"
+            ;;
+        "enterprise-storage" | "spindown-disk")
+            log_medium_risk "Your Tuned profile '$ACTIVE_PROFILE' is no longer supported, switched to the default Tuned profile."
+            ACTIVE_PROFILE=""
+            ;;
+        *)
+            log_medium_risk "You need to migrate your Tuned profile '$ACTIVE_PROFILE' by hand, switched to the default Tuned profile."
+            ACTIVE_PROFILE=""
+            ;;
+        esac
+        TUNED_CONF_DIR=$VALUE_TMP_PREUPGRADE/cleanconf/etc/tuned
+        mkdir -p $TUNED_CONF_DIR
+        echo $ACTIVE_PROFILE > $TUNED_CONF_DIR/active_profile
+        if [ "$ACTIVE_PROFILE" ]; then
+            echo "manual" > $TUNED_CONF_DIR/profile_mode
+        else
+            echo "auto" > $TUNED_CONF_DIR/profile_mode
+        fi
+    else
+        log_medium_risk "Unable to detect your active Tuned profile, not migrating it."
+    fi
+
+    BACKUP=""
+    if [ "$HAS_TUNED" = 1 ]; then
+        for f in $(ls -d /etc/tune-profiles/*/); do
+            if ! echo "$FILES" | grep -q "$f" || echo "$VERIFY" | grep -q "$f"; then
+                BACKUP="$BACKUP ${f%/}"
+            fi
+        done
+    fi
     sed -i s/POSTUPGRADE_DIR/\$POSTUPGRADE_TUNED_DIR/g solution.txt
-    cp -Rv $TUNED_DIR/* $POSTUPGRADE_TUNED_DIR
-    log_medium_risk "Tuned profiles were detected in the $TUNED_DIR directory. See the tuned-adm and tuned-profiles man pages for more information."
-    exit $RESULT_FAIL
+    if [ "$BACKUP" ]; then
+        cp -Rv -t $POSTUPGRADE_TUNED_DIR $BACKUP
+        log_medium_risk "Customized Tuned profiles were detected in the $TUNED_DIR directory. See the tuned-adm and tuned-profiles man pages for more information."
+        exit $RESULT_FAIL
+    fi
+    exit $RES
 fi
 
 exit $RESULT_NOT_APPLICABLE
-
-
-

--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -67,9 +67,13 @@ if [[ -d "$TUNED_DIR" ]]; then
         fi
     done
 
-    # copy the post-upgrade script
-    cp -a "zz_tuned_post.sh" "$POSTUPGRADE_DIR"
-    chmod +x "$POSTUPGRADE_DIR/zz_tuned_post.sh"
+    if [ "$RES" != "$RESULT_PASS" ]; then
+        # copy the post-upgrade script (in case of $RESULT_PASS, in this phase
+        # of the check, there is no reason for the postupgrade seatbelt here,
+        # in such case do not do anything)
+        cp -a "zz_tuned_post.sh" "$POSTUPGRADE_DIR"
+        chmod +x "$POSTUPGRADE_DIR/zz_tuned_post.sh"
+    fi
 
     sed -i "s|TUNED_BACKUP_DIR|$TUNED_BACKUP_DIR|g" solution.txt
     if [ "$BACKUP_LIST" ]; then

--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -6,18 +6,13 @@
 
 check_pkg() {
   is_pkg_installed "$1" || return 1
-  is_dist_native "$1" && return 0
-  log_info "The $1 is installed but not signed by Red Hat. Skipping"
-  return 1
+  is_dist_native "$1" || return 1
+  return 0
 }
-
-check_pkg "tuned"
-HAS_TUNED=$?
 
 FILES=""
 VERIFY=""
 for pkg in tuned tuned-profiles-{sap,sap-hana,oracle}; do
-    echo "$pkg"
     check_pkg "$pkg" || continue
     FILES="$FILES $(rpm -ql "$pkg" 2> /dev/null)"
     VERIFY="$VERIFY $(rpm -qV "$pkg" 2> /dev/null)"
@@ -68,13 +63,16 @@ if [[ -d "$TUNED_DIR" ]]; then
     fi
 
     BACKUP_LIST=""
-    if [ "$HAS_TUNED" = 1 ]; then
-        for f in $(ls -d /etc/tune-profiles/*/); do
-            if ! echo "$FILES" | grep -q "$f" || echo "$VERIFY" | grep -q "$f"; then
-                BACKUP_LIST="$BACKUP_LIST ${f%/}"
-            fi
-        done
-    fi
+    for f in $(ls -d /etc/tune-profiles/*/); do
+        if ! echo "$FILES" | grep -q "$f" || echo "$VERIFY" | grep -q "$f"; then
+            BACKUP_LIST="$BACKUP_LIST ${f%/}"
+        fi
+    done
+
+    # copy the post-upgrade script
+    cp -a "zz_tuned_post.sh" "$POSTUPGRADE_DIR"
+    chmod +x "$POSTUPGRADE_DIR/zz_tuned_post.sh"
+
     sed -i "s|TUNED_BACKUP_DIR|$TUNED_BACKUP_DIR|g" solution.txt
     if [ "$BACKUP_LIST" ]; then
         cp -a -t $TUNED_BACKUP_DIR $BACKUP_LIST
@@ -84,4 +82,5 @@ if [[ -d "$TUNED_DIR" ]]; then
     exit $RES
 fi
 
+log_debug "The $TUNED_DIR dir doesn't exist. Nothing to do."
 exit $RESULT_NOT_APPLICABLE

--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -4,20 +4,30 @@
 
 #END GENERATED SECTION
 
-FILES=$(rpm -ql tuned 2> /dev/null) && HAS_TUNED=1
-VERIFY=$(rpm -qV tuned 2> /dev/null)
-FILES="$FILES $(rpm -ql tuned-profiles-sap 2> /dev/null)"
-VERIFY="$VERIFY $(rpm -qV tuned-profiles-sap 2> /dev/null)"
-FILES="$FILES $(rpm -ql tuned-profiles-sap-hana 2> /dev/null)"
-VERIFY="$VERIFY $(rpm -qV tuned-profiles-sap-hana 2> /dev/null)"
-FILES="$FILES $(rpm -ql tuned-profiles-oracle 2> /dev/null)"
-VERIFY="$VERIFY $(rpm -qV tuned-profiles-oracle 2> /dev/null)"
+check_pkg() {
+  is_pkg_installed "$1" || return 1
+  is_dist_native "$1" && return 0
+  log_info "The $1 is installed but not signed by Red Hat. Skipping"
+  return 1
+}
+
+check_pkg "tuned"
+HAS_TUNED=$?
+
+FILES=""
+VERIFY=""
+for pkg in tuned tuned-profiles-{sap,sap-hana,oracle}; do
+    echo "$pkg"
+    check_pkg "$pkg" || continue
+    FILES="$FILES $(rpm -ql "$pkg" 2> /dev/null)"
+    VERIFY="$VERIFY $(rpm -qV "$pkg" 2> /dev/null)"
+done
 
 TUNED_DIR="/etc/tune-profiles/"
 if [[ -d "$TUNED_DIR" ]]; then
-    POSTUPGRADE_TUNED_DIR="$VALUE_TMP_PREUPGRADE/postupgrade.d/tuned"
-    if [[ ! -d "$POSTUPGRADE_TUNED_DIR" ]]; then
-        mkdir -p "$POSTUPGRADE_TUNED_DIR"
+    TUNED_BACKUP_DIR="$VALUE_TMP_PREUPGRADE/backup/tuned"
+    if [[ ! -d "$TUNED_BACKUP_DIR" ]]; then
+        mkdir -p "$TUNED_BACKUP_DIR"
     fi
 
     RES=$RESULT_FAIL
@@ -57,17 +67,17 @@ if [[ -d "$TUNED_DIR" ]]; then
         log_medium_risk "Unable to detect your active Tuned profile, not migrating it."
     fi
 
-    BACKUP=""
+    BACKUP_LIST=""
     if [ "$HAS_TUNED" = 1 ]; then
         for f in $(ls -d /etc/tune-profiles/*/); do
             if ! echo "$FILES" | grep -q "$f" || echo "$VERIFY" | grep -q "$f"; then
-                BACKUP="$BACKUP ${f%/}"
+                BACKUP_LIST="$BACKUP_LIST ${f%/}"
             fi
         done
     fi
-    sed -i s/POSTUPGRADE_DIR/\$POSTUPGRADE_TUNED_DIR/g solution.txt
-    if [ "$BACKUP" ]; then
-        cp -Rv -t $POSTUPGRADE_TUNED_DIR $BACKUP
+    sed -i "s|TUNED_BACKUP_DIR|$TUNED_BACKUP_DIR|g" solution.txt
+    if [ "$BACKUP_LIST" ]; then
+        cp -a -t $TUNED_BACKUP_DIR $BACKUP_LIST
         log_medium_risk "Customized Tuned profiles were detected in the $TUNED_DIR directory. See the tuned-adm and tuned-profiles man pages for more information."
         exit $RESULT_FAIL
     fi

--- a/RHEL6_7/system/tuned/check
+++ b/RHEL6_7/system/tuned/check
@@ -21,9 +21,7 @@ done
 TUNED_DIR="/etc/tune-profiles/"
 if [[ -d "$TUNED_DIR" ]]; then
     TUNED_BACKUP_DIR="$VALUE_TMP_PREUPGRADE/backup/tuned"
-    if [[ ! -d "$TUNED_BACKUP_DIR" ]]; then
-        mkdir -p "$TUNED_BACKUP_DIR"
-    fi
+    mkdir -p "$TUNED_BACKUP_DIR"
 
     RES=$RESULT_FAIL
     if [ -f /etc/tune-profiles/active-profile ]; then

--- a/RHEL6_7/system/tuned/module.ini
+++ b/RHEL6_7/system/tuned/module.ini
@@ -3,4 +3,5 @@ content_title: The 'tuned' profiles
 author: Petr Hracek <phracek@redhat.com>
 content_description: The module checks for the custom 'tuned' profiles on the system, and it stores them to the postupgrade directory.
 bugzilla: 1078293
+applies_to: tuned
 mode: migrate

--- a/RHEL6_7/system/tuned/solution.txt
+++ b/RHEL6_7/system/tuned/solution.txt
@@ -1,4 +1,3 @@
-After the upgrade to Red Hat Enterprise Linux (RHEL) 7, the profiles can be migrated manually with the help of the 'tuned-man' and 'tuned-profiles' commands to the /etc/tuned/ directory.
-It is recommended to execute the "tuned-adm recommend" command after the upgrade on the RHEL 7 system. If the output differs from the active profile, reconsider change of the active profile to the recommended one.
+After the upgrade to Red Hat Enterprise Linux (RHEL) 7, the profiles can be migrated manually to the /etc/tuned/ directory with the help of the 'tuned' and 'tuned-profiles' manual pages and 'tuned' documentation.
 Customized and third party tuned profiles are backed up in 'TUNED_BACKUP_DIR'.
-For more information about 'tuned', see [link:http://docs.fedoraproject.org/en-US/Fedora/20/html/Power_Management_Guide/tuned.html].
+For more information about 'tuned', see [link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/performance_tuning_guide/index#chap-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Tuned].

--- a/RHEL6_7/system/tuned/solution.txt
+++ b/RHEL6_7/system/tuned/solution.txt
@@ -1,4 +1,4 @@
-The module stores the custom 'tuned' profiles, which are located in the /etc/tune-profiles/ directory, to POSTUPGRADE_DIR.
-
-After the upgrade to Red Hat Enterprise Linux 7, the profiles can be migrated manually with the help of the 'tuned-man' and 'tuned-profiles' commands to the /etc/tuned/ directory.
+After the upgrade to Red Hat Enterprise Linux (RHEL) 7, the profiles can be migrated manually with the help of the 'tuned-man' and 'tuned-profiles' commands to the /etc/tuned/ directory.
+It is recommended to execute the "tuned-adm recommend" command after the upgrade on the RHEL 7 system. If the output differs from the active profile, reconsider change of the active profile to the recommended one.
+Customized and third party tuned profiles are backed up in 'TUNED_BACKUP_DIR'.
 For more information about 'tuned', see [link:http://docs.fedoraproject.org/en-US/Fedora/20/html/Power_Management_Guide/tuned.html].

--- a/RHEL6_7/system/tuned/zz_tuned_post.sh
+++ b/RHEL6_7/system/tuned/zz_tuned_post.sh
@@ -22,7 +22,7 @@ fi
 
 
 ACTIVE_PROFILE=$(cat "/etc/tuned/active_profile")
-if [ "$ACTIVE_PROFILE" != "$REC_PROFILE" ]; then
+if [ "$ACTIVE_PROFILE" -a "$ACTIVE_PROFILE" != "$REC_PROFILE" ]; then
     msg="Warning: The recommended tuned profile '$REC_PROFILE' is different"
     msg+=" from the active one '$ACTIVE_PROFILE'. Consider the change of the"
     msg+=" profile."

--- a/RHEL6_7/system/tuned/zz_tuned_post.sh
+++ b/RHEL6_7/system/tuned/zz_tuned_post.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Execute `tuned-adm recommend` and compare it against the current active
+# profile. Regarding the possible states of the system during the postupgrade
+# phase, it's possible the command will ends with error. We do not want to
+# produce any such an error msg to confuse user. Instead of that, focus just
+# on the thing that we want to give an extra information to user automatically
+# if possible. It does not affect the upgrade process at all.
+
+# IMPORTANT: the script has to be run after 'z_copy_clean_conf.sh'. Otherwise
+# tuned's config files will not be migrated yet. So keeping the name of this
+# script to ensure it will be executed after the cleanconf files are applied..
+
+REC_PROFILE=$(tuned-adm recommend 2>/dev/null)
+if [ $? -ne 0 ]; then
+    # ok, tuned probably doesn't work correctly right now in the post-upgrade
+    # "mode", let's keep it on user to follow remediation instruction from
+    # the preupgrade report
+    echo >&2 "Info: cannot get the recommended set up for tuned right now. Skip."
+    exit 0
+fi
+
+
+ACTIVE_PROFILE=$(cat "/etc/tuned/active_profile")
+if [ "$ACTIVE_PROFILE" != "$REC_PROFILE" ]; then
+    msg="Warning: The recommended tuned profile '$REC_PROFILE' is different"
+    msg+=" from the active one '$ACTIVE_PROFILE'. Consider the change of the"
+    msg+=" profile."
+    echo >&2 "$msg"
+fi


### PR DESCRIPTION
Related: https://projects.engineering.redhat.com/browse/OAMG-3185

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>

It adds more check logic. Currently the code doesn't work for profiles with spaces in the name (I am not sure whether it's supported, if yes, feel free to update the code).

It works the following way:
- it backups profiles which it doesn't recognize (i.e. profiles we don't ship)
- it backups profiles that we ship in case they were modified
- profiles that we ship are not backed up if they weren't modified
- backed up profiles needs to be hand migrated
- it maps active_profile to the known replacement profile
- if it cannot recognize the active_profile or if it is not supported, it uses the default recommended profile

Also it wouldn't be bad if it could run check after the migration (i.e. on the RHEL-7). In such case I would recommend running `tuned-adm recommend` (on the RHEL-7) and if its output differs from the $ACTIVE_PROFILE it could warn user that her or his profile is different from the recommended one and that she or he could reconsider using the recommended defaults.