### PR TITLE
system/SysconfigCgroupDaemon: handle dead symlinks

### DIFF
--- a/RHEL6_7/system/SysconfigCgroupDaemon/check
+++ b/RHEL6_7/system/SysconfigCgroupDaemon/check
@@ -41,8 +41,14 @@ def cgroup_daemon():
 	found = False
 	for root, dirs, files in os.walk('/etc/sysconfig'):
 		for filename in files:
-			with open(root+"/"+filename, "r") as f:
-				data = f.read()
+			try:
+				with open(root+"/"+filename, "r") as f:
+					data = f.read()
+			except IOError as e:
+				if e.errno in [errno.ENOENT, errno.EMLINK, errno.ELOOP]:
+					# skip dead symlinks
+					continue
+				raise e
 			if cgroup_re.search(data):
 				found = True
 				log_slight_risk("The " + filename + " file mentions CGROUP_DAEMON.")


### PR DESCRIPTION
The module crashes on dead symlink under /etc/sysconfig
```python
Traceback (most recent call last):
  File "/root/preupgrade/RHEL6_7/system/SysconfigCgroupDaemon/check", line 72, in <module>
    if cgroup_daemon():
  File "/root/preupgrade/RHEL6_7/system/SysconfigCgroupDaemon/check", line 62, in cgroup_daemon
    with open(root+"/"+filename, "r") as f:
IOError: [Errno 2] No such file or directory: '/etc/sysconfig/deadlink'
```

See the RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1851322
Thanks to @rmetrich for the patch.