### PR TITLE
 UEFI: fix 'back up' in the pre/post upgrade script

### DIFF
--- a/RHEL6_7/system/uefi/efibootorder_fix.sh
+++ b/RHEL6_7/system/uefi/efibootorder_fix.sh
@@ -23,11 +23,17 @@ if [ -e "$efibin_path" ] ; then
     # backup these files
     log_info "Backing up EFI files."
     cp -a ${efibin_path}{,.preupg}
-    cp -a ${eficonf_path}{,.preupg}
+    # back up the file only in case there is not any other backup
+    # - the backup can be created by redhat-upgrade-tool
+    [ -e "${eficonf_path}.preupg" ] || cp -a ${eficonf_path}{.preupg,}
 else
     # restore the files from the backup
     log_info "Restoring EFI files."
     cp -a ${efibin_path}{.preupg,}
+    # we do not want to apply the backup of the configuration file,
+    # as the backup will not contain probably working configuration; however,
+    # in case the configuration file is already missing, it could be in some
+    # rare cases better than nothing
     [ -e "$eficonf_path" ] || cp -a ${eficonf_path}{.preupg,}
 fi
 


### PR DESCRIPTION
    Originally the pre-upgrade script backed up the efi binary file and
    the grub configuration file. But in case the rollback capability is
    used with r-u-t (fixed one; original upstream r-u-t doesn't support
    rollbacks on EFI boot), the backed up version of the file could
    already exist - and another back up during the execution of the
    pre-upgrade script could override the original one. That means
    the rollback could produce a grub configuration that contains
    invalid entries.
    
    As well, I have been thinking about validity of the back up of the
    configuration file by the pre-upgrade script, as in case the
    configuration file is removed during the upgrade, the restore from
    the back up in majority cases will not safe anything as it will
    contain usually invalid entries. But in some cases, it could 'safe
    world'. E.g. manually created entries without referrence to specific
    kernel version & release (e.g. rescue entry) could be still working
    and provide required environment to rescue the machine (or e.g.
    create valid bootloader configuration). So I am keeping it there,
    as in case that bootloader is already broken, it would only 'safe the
    world'.

