### PR TITLE
Bump to version 0.8.0

### DIFF
--- a/packaging/preupgrade-assistant-el6toel7.spec
+++ b/packaging/preupgrade-assistant-el6toel7.spec
@@ -4,7 +4,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}
 
 Name:           preupgrade-assistant-el6toel7
-Version:        0.7.9
+Version:        0.8.0
 Release:        1%{?dist}
 Summary:        Set of modules created for upgrade to Red Hat Enterprise Linux 7
 Group:          System Environment/Libraries

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
-Version 0.7.9
+Version 0.8.0
 DataVersion 0
 6.10-7.9


### PR DESCRIPTION
- Switch the upgrade path to RHEL 6.10 -> RHEL 7.9
- Enable upgrades with EFI boot
- Inhibit upgrade when by-path is used in /etc/fstab
- Drop the broken InterVariants module
- Fix and improve migration of tuned
- Fix networking issues around network-manager and route-eth* files
  (RHBZ: #1644915, #1816751)
- Fix report from the networking/openldap module
- Fix syntax error in the other/configchanges module
- Handle dead symlinksi in the system/SysconfigCgroupDaemon module