### PR TITLE
Uefi fix

### DIFF
--- a/RHEL6_7/system/uefi/check
+++ b/RHEL6_7/system/uefi/check
@@ -24,10 +24,10 @@ command -v efibootmgr >/dev/null || {
 }
 
 # create pre-upgrade and post-upgrade scripts
-cp -a "efibootorder_fix.sh" "$PREUPGRADE_SCRIPT_DIR/"
-cp -a "efibootorder_fix.sh" "$POSTUPGRADE_DIR/"
-chmod +x "$PREUPGRADE_SCRIPT_DIR/efibootorder_fix.sh"
-chmod +x "$POSTUPGRADE_DIR/efibootorder_fix.sh"
+cp -a "efibootorder_fix_pre.sh" "$PREUPGRADE_SCRIPT_DIR/"
+cp -a "efibootorder_fix_post.sh" "$POSTUPGRADE_DIR/"
+chmod +x "$PREUPGRADE_SCRIPT_DIR/efibootorder_fix_pre.sh"
+chmod +x "$POSTUPGRADE_DIR/efibootorder_fix_post.sh"
 
 log_medium_risk "The Legacy GRUB has to be migrated to GRUB 2 after the upgrade manually"
 exit_fail

--- a/RHEL6_7/system/uefi/efibootorder_fix_post.sh
+++ b/RHEL6_7/system/uefi/efibootorder_fix_post.sh
@@ -18,25 +18,15 @@ efibootmgr || {
 # rpm which is removed during the upgrade
 efibin_path="/boot/efi/EFI/redhat/grub.efi"
 eficonf_path="/boot/efi/EFI/redhat/grub.conf"
-if [ -e "$efibin_path" ] ; then
-    # now we are for sure on the original system, as the binary is not removed
-    # backup these files
-    log_info "Backing up EFI files."
-    cp -a ${efibin_path}{,.preupg}
-    # back up the file only in case there is not any other backup
-    # - the backup can be created by redhat-upgrade-tool
-    [ -e "${eficonf_path}.preupg" ] || cp -a ${eficonf_path}{.preupg,}
-else
-    # restore the files from the backup
-    log_info "Restoring EFI files."
-    cp -a ${efibin_path}{.preupg,}
-    # we do not want to apply the backup of the configuration file,
-    # as the backup will not contain probably working configuration; however,
-    # in case the configuration file is already missing, it could be in some
-    # rare cases better than nothing
-    [ -e "$eficonf_path" ] || cp -a ${eficonf_path}{.preupg,}
-fi
 
+# restore the files from the backup
+log_info "Restoring EFI files."
+cp -a ${efibin_path}{.preupg,}
+# we do not want to apply the backup of the configuration file,
+# as the backup will not contain probably working configuration; however,
+# in case the configuration file is already missing, it could be in some
+# rare cases better than nothing
+[ -e "$eficonf_path" ] || cp -a ${eficonf_path}{.preupg,}
 
 
 # e.g.: BootCurrent: 0001

--- a/RHEL6_7/system/uefi/efibootorder_fix_post.sh
+++ b/RHEL6_7/system/uefi/efibootorder_fix_post.sh
@@ -8,25 +8,46 @@ log_error() {
     echo >&2 "Error: $@"
 }
 
+
+################################
+# Handling set of install grub related RPMs
+# - legacy grub is expected to be removed (before or during this script)
+# - the grub2 package is expected to be installed
+# - efiboot package is expected to be installed
+################################
+rpm -q grub >/dev/null && {
+    # the legacy grub is still installed. Remove it first and install the grub2
+    # we have to recover the EFI boot binary after the grub is uninstalled
+    log_info "The legacy grub is still installed. Uninstalling.."
+    yum -y remove grub
+}
+
+rpm -q grub2 grub2-efi efibootmgr >/dev/null || {
+    log_info "Installing grub2, grub2-efi, and efibootmgr packages"
+    yum -y install grub2 grub2-efi efibootmgr
+}
+
+# the $efibin_path is removed (as it is provided by the grub rpm which is
+# supposed to be always removed).
+efibin_path="/boot/efi/EFI/redhat/grub.efi"
+eficonf_path="/boot/efi/EFI/redhat/grub.conf"
+
+# restore the EFI file from the backup (we want to reach this step always)
+log_info "Restoring EFI files."
+cp -a ${efibin_path}{.preupg,}
+
+# we do not want to apply the backup of the configuration file,
+# as the backup will not contain probably working configuration; however,
+# in case the configuration file is already missing, it could be in some
+# rare cases better than nothing
+[ -e "$eficonf_path" ] || cp -a ${eficonf_path}{.preupg,}
+
 log_info "Check the EFI:"
 efibootmgr || {
     log_error "Something is wrong. Cannot use the efibootmgr utility"
     exit 1
 }
 
-# the $efibin_path is removed during the upgrade as it is provided by the grub
-# rpm which is removed during the upgrade
-efibin_path="/boot/efi/EFI/redhat/grub.efi"
-eficonf_path="/boot/efi/EFI/redhat/grub.conf"
-
-# restore the files from the backup
-log_info "Restoring EFI files."
-cp -a ${efibin_path}{.preupg,}
-# we do not want to apply the backup of the configuration file,
-# as the backup will not contain probably working configuration; however,
-# in case the configuration file is already missing, it could be in some
-# rare cases better than nothing
-[ -e "$eficonf_path" ] || cp -a ${eficonf_path}{.preupg,}
 
 
 # e.g.: BootCurrent: 0001

--- a/RHEL6_7/system/uefi/efibootorder_fix_pre.sh
+++ b/RHEL6_7/system/uefi/efibootorder_fix_pre.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+log_info() {
+    echo >&2 "Info: $@"
+}
+
+log_error() {
+    echo >&2 "Error: $@"
+}
+
+log_info "Check the EFI:"
+efibootmgr || {
+    log_error "Something is wrong. Cannot use the efibootmgr utility"
+    exit 1
+}
+
+# the $efibin_path is removed during the upgrade as it is provided by the grub
+# rpm which is removed during the upgrade
+efibin_path="/boot/efi/EFI/redhat/grub.efi"
+eficonf_path="/boot/efi/EFI/redhat/grub.conf"
+if [ -e "$efibin_path" ] ; then
+    # now we are for sure on the original system, as the binary is not removed
+    # backup these files
+    log_info "Backing up EFI files."
+    cp -a ${efibin_path}{,.preupg}
+    # back up the file only in case there is not any other backup
+    # - the backup can be created by redhat-upgrade-tool
+    [ -e "${eficonf_path}.preupg" ] || cp -a ${eficonf_path}{,.preupg}
+else
+    # This is not expected at all, but let's call it a lock for a seatbelt
+    # - The script is applied only when EFI is detected; however it's possible
+    #   the system could be deployed already broken and still working by
+    #   a miracle (unsupported of course, but why not to prevent more damage?)
+    log_error "Cannot find the $eficonf_path file but EFI has been detected. Cannot proceed the upgrade."
+    exit 1
+fi
+
+
+
+# e.g.: BootCurrent: 0001
+current_boot=$(efibootmgr | grep "^BootCurrent:" | cut -d ":" -f 2- | sed -r "s/^\s*(.*)\s*$/\1/" | grep -o "^[0-9A-F]*")
+[ -z "$current_boot" ] && {
+    log_error "Cannot detect the current EFI boot using the efibootmgr"
+    exit 1
+}
+log_info "The current EFI boot is: $current_boot"
+
+# e.g. BootNext: 0001
+next_boot=$(efibootmgr | grep "^BootNext:" | cut -d ":" -f 2- | sed -r "s/^\s*(.*)\s*$/\1/" | grep -o "^[0-9A-F]*")
+[ -z "$next_boot" ] && {
+    # We set BootNext to CurrentBoot only if BootNext wasn't previously set
+    log_info "Setting the next boot to: $current_boot"
+    efibootmgr -n "$current_boot" || {
+        log_error "Cannot set the next boot properly using the efibootmgr utility"
+        exit 1
+    }
+    exit 0
+}
+
+log_info "The next boot is already set to: ${next_boot}. Nothing to do"
+exit 0


### PR DESCRIPTION
In case r-u-t is called without the --cleaup-post option, the postupgrade script recovering the EFI (bin and config) files do not recover the files because the legacy grub is still installed.

In addition, several other minor issues have been present. Fixing those:

- Split the pre & post upgrade script into two separate files to make it less buggy
- Pre-upgrade script:
  - fixed minor issues for the back up of grub files during pre-upgrade checks
  - stop the upgrade if the efi binary file does not exist (it must; this is just seatbelt, it is not expected issue and there is not valid installation of RHEL that could be used as reproducer)
- Post-upgrade script:
  - remove the grub rpm if installed
  - install grub2, grub2-efi, and efiboot rpms if any missing
  - always restore the grub.efi binary file (that's difference between broken bootloader and working one...)
  - restore grub config file if original one dissapeared
 
https://bugzilla.redhat.com/show_bug.cgi?id=1915393